### PR TITLE
feat(chat): setup chat based trading for CL

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -13,12 +13,20 @@ tasks:
 
   api:
     desc: Start the FastAPI backend (port 8000)
-    cmd: uv run uvicorn src.api.main:app --reload --port 8000
+    cmd: op run --env-file=.env.{{.ENV}} -- uv run uvicorn src.api.main:app --reload --port 8000
 
   frontend:
     desc: Start the Vite dev server (port 5173)
     dir: frontend
     cmd: npm run dev
+
+  worker:orders:
+    desc: Start order execution worker (separate process)
+    cmd: op run --env-file=.env.{{.ENV}} -- uv run python scripts/work_order_queue.py --env {{.ENV}}
+
+  worker:jobs:
+    desc: Start generic job worker (dispatches by job_type)
+    cmd: op run --env-file=.env.{{.ENV}} -- uv run python scripts/work_jobs.py --env {{.ENV}}
 
   frontend:install:
     desc: Install frontend dependencies

--- a/alembic/versions/20260219090000_add_orders_and_order_events_tables.py
+++ b/alembic/versions/20260219090000_add_orders_and_order_events_tables.py
@@ -1,0 +1,76 @@
+"""add orders and order events tables
+
+Revision ID: c8f4d1e9a731
+Revises: b7d1e2f3a4c5
+Create Date: 2026-02-19 09:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c8f4d1e9a731"
+down_revision: Union[str, Sequence[str], None] = "b7d1e2f3a4c5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "orders",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("account_id", sa.Integer, nullable=False),
+        sa.Column("symbol", sa.String, nullable=False),
+        sa.Column("sec_type", sa.String, nullable=False),
+        sa.Column("exchange", sa.String, nullable=False),
+        sa.Column("currency", sa.String, nullable=False),
+        sa.Column("side", sa.String, nullable=False),
+        sa.Column("quantity", sa.Integer, nullable=False),
+        sa.Column("order_type", sa.String, nullable=False),
+        sa.Column("tif", sa.String, nullable=False),
+        sa.Column("status", sa.String, nullable=False),
+        sa.Column("source", sa.String, nullable=False),
+        sa.Column("con_id", sa.Integer, nullable=True),
+        sa.Column("local_symbol", sa.String, nullable=True),
+        sa.Column("trading_class", sa.String, nullable=True),
+        sa.Column("contract_month", sa.String, nullable=True),
+        sa.Column("contract_expiry", sa.String, nullable=True),
+        sa.Column("ib_order_id", sa.Integer, nullable=True),
+        sa.Column("ib_perm_id", sa.Integer, nullable=True),
+        sa.Column("filled_quantity", sa.Float, nullable=False, server_default="0"),
+        sa.Column("avg_fill_price", sa.Float, nullable=True),
+        sa.Column("last_error", sa.Text, nullable=True),
+        sa.Column("request_text", sa.Text, nullable=True),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_index("ix_orders_status_created_at", "orders", ["status", "created_at"])
+
+    op.create_table(
+        "order_events",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("order_id", sa.Integer, nullable=False),
+        sa.Column("event_type", sa.String, nullable=False),
+        sa.Column("message", sa.Text, nullable=False),
+        sa.Column("status", sa.String, nullable=True),
+        sa.Column("filled_quantity", sa.Float, nullable=True),
+        sa.Column("avg_fill_price", sa.Float, nullable=True),
+        sa.Column("ib_order_id", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_order_events_order_id_created_at", "order_events", ["order_id", "created_at"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_order_events_order_id_created_at", table_name="order_events")
+    op.drop_table("order_events")
+    op.drop_index("ix_orders_status_created_at", table_name="orders")
+    op.drop_table("orders")

--- a/alembic/versions/20260219100000_add_jobs_table.py
+++ b/alembic/versions/20260219100000_add_jobs_table.py
@@ -1,0 +1,49 @@
+"""add jobs table
+
+Revision ID: d2e13c7745ab
+Revises: c8f4d1e9a731
+Create Date: 2026-02-19 10:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d2e13c7745ab"
+down_revision: Union[str, Sequence[str], None] = "c8f4d1e9a731"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "jobs",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("job_type", sa.String, nullable=False),
+        sa.Column("status", sa.String, nullable=False),
+        sa.Column("payload", sa.JSON, nullable=False),
+        sa.Column("result", sa.JSON, nullable=True),
+        sa.Column("source", sa.String, nullable=False),
+        sa.Column("request_text", sa.Text, nullable=True),
+        sa.Column("attempts", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("max_attempts", sa.Integer, nullable=False, server_default="3"),
+        sa.Column("available_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_error", sa.Text, nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index(
+        "ix_jobs_status_available_created",
+        "jobs",
+        ["status", "available_at", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_status_available_created", table_name="jobs")
+    op.drop_table("jobs")

--- a/alembic/versions/20260219110000_add_worker_heartbeats_table.py
+++ b/alembic/versions/20260219110000_add_worker_heartbeats_table.py
@@ -1,0 +1,44 @@
+"""add worker heartbeats table
+
+Revision ID: e4f2a9b56c80
+Revises: d2e13c7745ab
+Create Date: 2026-02-19 11:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e4f2a9b56c80"
+down_revision: Union[str, Sequence[str], None] = "d2e13c7745ab"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "worker_heartbeats",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column("worker_type", sa.String, nullable=False),
+        sa.Column("status", sa.String, nullable=False),
+        sa.Column("details", sa.Text, nullable=True),
+        sa.Column("heartbeat_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("worker_type", name="uq_worker_heartbeats_worker_type"),
+    )
+    op.create_index(
+        "ix_worker_heartbeats_worker_type_heartbeat_at",
+        "worker_heartbeats",
+        ["worker_type", "heartbeat_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_worker_heartbeats_worker_type_heartbeat_at",
+        table_name="worker_heartbeats",
+    )
+    op.drop_table("worker_heartbeats")

--- a/alembic/versions/20260219120000_add_jobs_archived_at.py
+++ b/alembic/versions/20260219120000_add_jobs_archived_at.py
@@ -1,0 +1,28 @@
+"""add jobs archived_at
+
+Revision ID: f7a3c1d8e2b4
+Revises: e4f2a9b56c80
+Create Date: 2026-02-19 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a3c1d8e2b4"
+down_revision: Union[str, Sequence[str], None] = "e4f2a9b56c80"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("jobs", sa.Column("archived_at", sa.DateTime(timezone=True), nullable=True))
+    op.create_index("ix_jobs_archived_at", "jobs", ["archived_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_jobs_archived_at", table_name="jobs")
+    op.drop_column("jobs", "archived_at")

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -3,6 +3,9 @@
 | File | Tags | Description |
 |------|------|-------------|
 | [spec-installable-internal-app-layout.md](spec-installable-internal-app-layout.md) | architecture, uv, packaging, src-layout | Spec for migrating from `src` imports to an installable internal package at `src/ngtrader` |
+| [spec-worker-order-recovery.md](spec-worker-order-recovery.md) | orders, worker, recovery, tws, failover | Spec for reboot-safe order worker lifecycle and recovery with a 42-step implementation plan |
+| [tradebot-chatbot.md](tradebot-chatbot.md) | tradebot, chatbot, api, ui | Chatbot behavior, intent routing, constraints, and UI components |
+| [tradebot-workers.md](tradebot-workers.md) | workers, jobs, orders, heartbeat, architecture | Worker construction details for job processing, order execution, heartbeats, and operational flow |
 | [execute-future-cl-order-script.md](execute-future-cl-order-script.md) | ibkr, futures, execution, cl | Short runbook for executing the CL April 2026 market order script |
 | [secrets-using-1password.md](secrets-using-1password.md) | secrets, 1password, env | Using 1Password CLI to manage secrets in `.env.dev` and `.env.prod` files |
 | [download-positions.md](download-positions.md) | ibkr, postgres, positions, db | Download IBKR positions from TWS and store in Postgres |

--- a/docs/spec-worker-order-recovery.md
+++ b/docs/spec-worker-order-recovery.md
@@ -1,0 +1,97 @@
+# Spec: Worker Order Recovery
+
+## Purpose
+
+Define how `worker:orders` survives restarts/crashes without losing state or duplicating live orders in TWS.
+
+## Scope
+
+- Order queue lifecycle in `orders` and `order_events`.
+- Worker reboot and failover behavior.
+- TWS reconciliation on startup.
+- UI-visible progress and recovery state.
+
+## Non-goals
+
+- Strategy or risk model design.
+- Multi-broker abstraction.
+- Historical backfill outside active queued orders.
+
+## Required Invariants
+
+- Every order has one authoritative lifecycle in DB.
+- Worker crashes are recoverable.
+- Reboot never blindly re-submits a potentially live order.
+- Reconciliation runs before new submissions.
+- Every transition is appended to `order_events`.
+
+## Canonical States
+
+- `queued`
+- `submitting`
+- `submitted`
+- `partially_filled`
+- `filled` (terminal)
+- `cancelled` (terminal)
+- `rejected` (terminal)
+- `failed` (terminal)
+- `reconcile_required`
+
+## 42-Step Plan
+
+1. Add `worker_id` to `orders`.
+2. Add `lease_expires_at` to `orders`.
+3. Add `heartbeat_at` to `orders`.
+4. Add `order_ref` to `orders` (stable idempotency key).
+5. Add `retry_count` to `orders`.
+6. Add `max_retries` to `orders`.
+7. Add `reconcile_required` to `orders`.
+8. Add index on `(status, lease_expires_at, created_at)`.
+9. Update `Order` ORM model with new fields.
+10. Backfill `order_ref` for existing rows as `ngtrader-order-{id}`.
+11. Add state transition guard helper.
+12. Add transition validation tests.
+13. Worker starts and creates `worker_id` on boot.
+14. Worker connects to TWS before claim loop.
+15. Worker loads all non-terminal orders.
+16. Worker marks stale `submitting/submitted/partially_filled` as `reconcile_required`.
+17. Worker calls TWS open-order snapshot.
+18. Worker calls TWS executions/fills snapshot.
+19. Worker matches broker orders by `order_ref`.
+20. Worker matches fallback by `ib_order_id`/`ib_perm_id`.
+21. Worker updates matched DB rows with latest broker status.
+22. Worker appends reconciliation events to `order_events`.
+23. Worker closes rows now terminal (`filled/cancelled/rejected`).
+24. Worker sets unmatched non-terminal rows to `reconcile_required`.
+25. Worker enters claim loop after reconciliation.
+26. Claim uses transaction with row lock semantics.
+27. Claim only rows where `status in (queued,reconcile_required)`.
+28. Claim only rows where lease is null or expired.
+29. Claim sets `worker_id`, `lease_expires_at`, `heartbeat_at`.
+30. Claim sets state to `submitting`.
+31. Worker heartbeats every loop while order is active.
+32. Worker sets IB `orderRef=ngtrader-order-{id}` before submit.
+33. Worker persists `ib_order_id`/`ib_perm_id` immediately after submit.
+34. Worker sets state to `submitted` or `partially_filled`.
+35. Worker appends event each status/fill delta.
+36. If worker receives SIGTERM, stop claiming new rows.
+37. On SIGTERM, flush current order progress then disconnect TWS.
+38. If worker dies hard, lease expiry enables safe pickup.
+39. Rebooted worker reconciles first, then resumes claims.
+40. Retry logic: only retry if broker confirms no live order for `order_ref`.
+41. Mark permanently unresolved rows `failed` with explicit reason.
+42. UI displays recovery flags (`reconcile_required`, stale lease, last event timestamp).
+
+## Operational Rules
+
+- Always run `worker:orders` continuously in production.
+- On deploy, allow old worker to drain, then start new worker.
+- If outage occurs, restart worker and verify reconciliation events appear.
+- Manual intervention is required for orders stuck in `reconcile_required` after retries.
+
+## Acceptance Criteria
+
+- Killing worker mid-order does not lose order state.
+- Reboot does not duplicate submission for same order id.
+- Fill data remains monotonic and auditable in `order_events`.
+- Recovery path is visible in API/UI.

--- a/docs/tradebot-chatbot.md
+++ b/docs/tradebot-chatbot.md
@@ -1,0 +1,47 @@
+# Tradebot Chatbot
+
+## Purpose
+
+`/api/v1/tradebot/chat` is the chat control surface for operator requests.
+
+It currently supports:
+
+- Position summaries
+- Queueing `positions.sync` jobs
+- Queueing CL futures orders
+- Order/job progress summaries
+
+## Request/Response Model
+
+- Frontend uses Vercel AI SDK `useChat` with `TextStreamChatTransport`.
+- Client sends `messages[]` (`role` + `parts[]`).
+- Server reads latest user text and returns plain text.
+
+## Intent Routing
+
+Text is routed by simple intent parsing:
+
+- Position sync intent (`refresh/sync/fetch positions`) -> enqueue `jobs` row (`job_type=positions.sync`)
+- CL order intent (`buy|sell <qty> CL`) -> qualify front-month CL via TWS, then enqueue `orders` row
+- Status/progress intent -> summarize latest jobs/orders
+- Fallback -> usage hints
+
+## Current Constraints
+
+- Order intent currently supports only `CL` futures.
+- Account resolution uses `account <id|alias|account_number>` when provided; otherwise first account row.
+- Contract qualification requires TWS/Gateway connectivity.
+
+## UI Components
+
+- `TradebotChat` main chat panel
+- `JobsTable` side panel (job timing + actions)
+- `OrdersSideTable` side panel (order timing + status/fill)
+- Header worker lights from `/api/v1/workers/status`
+
+## Key Files
+
+- `src/api/routers/tradebot.py`
+- `frontend/src/components/TradebotChat.tsx`
+- `frontend/src/components/JobsTable.tsx`
+- `frontend/src/components/OrdersSideTable.tsx`

--- a/docs/tradebot-workers.md
+++ b/docs/tradebot-workers.md
@@ -1,0 +1,56 @@
+# Tradebot Workers
+
+## Purpose
+
+Workers run as separate processes and consume DB queues.
+
+- `worker:jobs` handles generic background jobs (`jobs` table).
+- `worker:orders` handles live TWS execution (`orders` table).
+
+## Construction
+
+### Jobs Worker
+
+- Entrypoint: `scripts/work_jobs.py`
+- Queue primitive: `src/services/jobs.py`
+- Current handler map:
+  - `positions.sync` -> `src/services/position_sync.py`
+- Claims queued jobs, runs handler, writes `result`/`status`, retries until `max_attempts`.
+
+### Orders Worker
+
+- Entrypoint: `scripts/work_order_queue.py`
+- Reads queued orders, qualifies contracts, submits to TWS, updates fill/status lifecycle.
+- Writes audit trail to `order_events`.
+
+## Heartbeats and Health
+
+- Heartbeats stored in `worker_heartbeats`.
+- Helper: `src/services/worker_heartbeat.py`
+- API status endpoint: `GET /api/v1/workers/status`
+- UI header lights map heartbeat freshness to green/yellow/red.
+
+## Data Flow
+
+1. Chat/API enqueues a row in `jobs` or `orders`.
+2. Worker claims row and performs external side effect (DB sync or TWS submit).
+3. Worker updates lifecycle fields and timestamps.
+4. UI polls tables and displays queue/run/total timing.
+
+## Start Commands
+
+```bash
+ENV=dev task worker:jobs
+ENV=dev task worker:orders
+```
+
+Both commands run under `op run --env-file=.env.<env>` to resolve `op://` references.
+
+## Key Files
+
+- `scripts/work_jobs.py`
+- `scripts/work_order_queue.py`
+- `src/services/jobs.py`
+- `src/services/position_sync.py`
+- `src/services/worker_heartbeat.py`
+- `src/api/routers/workers.py`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@ai-sdk/react": "^3.0.93",
+        "ai": "^6.0.91",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -26,6 +28,70 @@
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.50",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.50.tgz",
+      "integrity": "sha512-Jdd1a8VgbD7l7r+COj0h5SuaYRfPvOJ/AO6l0OrmTPEcI2MUQPr3C4JttfpNkcheEN+gOdy0CtZWuG17bW2fjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.15.tgz",
+      "integrity": "sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.93",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.93.tgz",
+      "integrity": "sha512-FY1HmeAfCpiAGLhIZh2QR8QFzHFZfhjMmkA9D5KC/O3eGqPeY7CwBABLkzRH+5Gkf+MfxXnEm4VF0MpmvDMjpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.15",
+        "ai": "6.0.91",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1011,6 +1077,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.3",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1367,6 +1442,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.1.18",
@@ -2011,6 +2092,15 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
@@ -2053,6 +2143,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.91",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.91.tgz",
+      "integrity": "sha512-k1/8BusZMhYVxxLZt0BUZzm9HVDCCh117nyWfWUx5xjR2+tWisJbXgysL7EBMq2lgyHwgpA1jDR3tVjWSdWZXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.50",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -2285,6 +2393,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2564,6 +2681,15 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2857,6 +2983,12 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -3579,6 +3711,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.0.tgz",
+      "integrity": "sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
@@ -3598,6 +3743,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tinyglobby": {
@@ -3729,6 +3886,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -3854,7 +4020,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.93",
+    "ai": "^6.0.91",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,10 +9,13 @@ type Page = "positions" | "accounts" | "orders" | "tradebot";
 
 function App() {
   const [page, setPage] = useState<Page>("tradebot");
+  const horizontalPaddingClass = page === "tradebot" ? "px-2 md:px-3" : "px-6";
 
   return (
     <div className="w-full">
-      <nav className="flex items-center gap-6 px-6 py-3 border-b border-gray-200 bg-white">
+      <nav
+        className={`flex items-center gap-6 ${horizontalPaddingClass} py-3 border-b border-gray-200 bg-white`}
+      >
         <span className="font-bold text-lg">ngtrader</span>
         <button
           onClick={() => setPage("positions")}
@@ -40,7 +43,7 @@ function App() {
         </button>
         <WorkerStatusLights />
       </nav>
-      <div className="px-6 py-6">
+      <div className={`${horizontalPaddingClass} py-6`}>
         {page === "positions" && <PositionsTable />}
         {page === "accounts" && <AccountsTable />}
         {page === "orders" && <OrdersTable />}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 import AccountsTable from "./components/AccountsTable";
+import OrdersTable from "./components/OrdersTable";
 import PositionsTable from "./components/PositionsTable";
+import TradebotChat from "./components/TradebotChat";
+import WorkerStatusLights from "./components/WorkerStatusLights";
 
-type Page = "positions" | "accounts";
+type Page = "positions" | "accounts" | "orders" | "tradebot";
 
 function App() {
-  const [page, setPage] = useState<Page>("positions");
+  const [page, setPage] = useState<Page>("tradebot");
 
   return (
     <div className="w-full">
@@ -23,10 +26,25 @@ function App() {
         >
           Accounts
         </button>
+        <button
+          onClick={() => setPage("orders")}
+          className={`text-sm ${page === "orders" ? "text-black font-semibold" : "text-gray-500 hover:text-gray-800"}`}
+        >
+          Orders
+        </button>
+        <button
+          onClick={() => setPage("tradebot")}
+          className={`text-sm ${page === "tradebot" ? "text-black font-semibold" : "text-gray-500 hover:text-gray-800"}`}
+        >
+          Tradebot
+        </button>
+        <WorkerStatusLights />
       </nav>
       <div className="px-6 py-6">
         {page === "positions" && <PositionsTable />}
         {page === "accounts" && <AccountsTable />}
+        {page === "orders" && <OrdersTable />}
+        {page === "tradebot" && <TradebotChat />}
       </div>
     </div>
   );

--- a/frontend/src/components/AccountsTable.tsx
+++ b/frontend/src/components/AccountsTable.tsx
@@ -42,12 +42,7 @@ export default function AccountsTable() {
     });
   };
 
-  useEffect(() => {
-    fetchAccounts();
-  }, []);
-
   function fetchAccounts() {
-    setLoading(true);
     fetch("http://localhost:8000/api/v1/accounts")
       .then((res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -57,6 +52,10 @@ export default function AccountsTable() {
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false));
   }
+
+  useEffect(() => {
+    fetchAccounts();
+  }, []);
 
   function startEdit(account: Account) {
     setEditingId(account.id);

--- a/frontend/src/components/JobsTable.tsx
+++ b/frontend/src/components/JobsTable.tsx
@@ -148,7 +148,7 @@ export default function JobsTable() {
     });
 
   return (
-    <div className="min-w-[460px] rounded border border-gray-300 bg-white p-3">
+    <div className="min-w-0 h-[460px] rounded border border-gray-300 bg-white p-3 flex flex-col">
       <div className="mb-2 flex items-center justify-between">
         <h3 className="text-sm font-semibold text-gray-900">Jobs</h3>
         <span className="text-xs text-gray-500">Auto-refresh 2.5s</span>
@@ -156,7 +156,7 @@ export default function JobsTable() {
 
       {error && <p className="mb-2 text-xs text-red-600">Error: {error}</p>}
 
-      <div className="max-h-[280px] overflow-auto">
+      <div className="min-h-0 flex-1 overflow-auto">
         <table className="min-w-full border-collapse text-xs">
           <thead>
             <tr className="bg-gray-100 text-left">

--- a/frontend/src/components/JobsTable.tsx
+++ b/frontend/src/components/JobsTable.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+
+interface Job {
+  id: number;
+  job_type: string;
+  status: string;
+  attempts: number;
+  max_attempts: number;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  archived_at: string | null;
+  last_error: string | null;
+}
+
+const STATUS_CLASS: Record<string, string> = {
+  queued: "text-yellow-700 bg-yellow-100",
+  running: "text-blue-700 bg-blue-100",
+  completed: "text-green-700 bg-green-100",
+  failed: "text-red-700 bg-red-100",
+};
+
+function parseTime(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "—";
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return `${hours}h ${remMinutes}m`;
+}
+
+function computeQueueMs(job: Job, nowMs: number): number {
+  const createdMs = parseTime(job.created_at) ?? nowMs;
+  const startedMs = parseTime(job.started_at);
+  return (startedMs ?? nowMs) - createdMs;
+}
+
+function computeRunMs(job: Job, nowMs: number): number | null {
+  const startedMs = parseTime(job.started_at);
+  if (startedMs === null) return null;
+  const completedMs = parseTime(job.completed_at);
+  return (completedMs ?? nowMs) - startedMs;
+}
+
+function computeTotalMs(job: Job, nowMs: number): number {
+  const createdMs = parseTime(job.created_at) ?? nowMs;
+  const completedMs = parseTime(job.completed_at);
+  return (completedMs ?? nowMs) - createdMs;
+}
+
+export default function JobsTable() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+  const [actioning, setActioning] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    let active = true;
+
+    const load = () => {
+      fetch("http://localhost:8000/api/v1/jobs")
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((rows: Job[]) => {
+          if (!active) return;
+          setJobs(rows.slice(0, 20));
+          setError(null);
+        })
+        .catch((err: Error) => {
+          if (!active) return;
+          setError(err.message);
+        });
+    };
+
+    load();
+    const timer = window.setInterval(load, 2500);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  const reload = () => {
+    fetch("http://localhost:8000/api/v1/jobs")
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((rows: Job[]) => {
+        setJobs(rows.slice(0, 20));
+        setError(null);
+      })
+      .catch((err: Error) => setError(err.message));
+  };
+
+  const withAction = (jobId: number, action: () => Promise<void>) => {
+    setActioning((prev) => {
+      const next = new Set(prev);
+      next.add(jobId);
+      return next;
+    });
+    action()
+      .then(() => reload())
+      .catch((err: Error) => setError(err.message))
+      .finally(() => {
+        setActioning((prev) => {
+          const next = new Set(prev);
+          next.delete(jobId);
+          return next;
+        });
+      });
+  };
+
+  const rerunJob = (jobId: number) =>
+    withAction(jobId, async () => {
+      const res = await fetch(`http://localhost:8000/api/v1/jobs/${jobId}/rerun`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+    });
+
+  const archiveJob = (jobId: number) =>
+    withAction(jobId, async () => {
+      const res = await fetch(`http://localhost:8000/api/v1/jobs/${jobId}/archive`, {
+        method: "POST",
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+    });
+
+  return (
+    <div className="min-w-[460px] rounded border border-gray-300 bg-white p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900">Jobs</h3>
+        <span className="text-xs text-gray-500">Auto-refresh 2.5s</span>
+      </div>
+
+      {error && <p className="mb-2 text-xs text-red-600">Error: {error}</p>}
+
+      <div className="max-h-[280px] overflow-auto">
+        <table className="min-w-full border-collapse text-xs">
+          <thead>
+            <tr className="bg-gray-100 text-left">
+              <th className="px-2 py-1 font-semibold text-gray-700">ID</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Type</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Status</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Queue</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Run</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Total</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {jobs.length === 0 && (
+              <tr>
+                <td className="px-2 py-2 text-gray-500" colSpan={7}>
+                  No jobs yet.
+                </td>
+              </tr>
+            )}
+            {jobs.map((job) => (
+              <tr key={job.id} className="border-b border-gray-200 align-top">
+                <td className="px-2 py-1 font-mono text-gray-800">{job.id}</td>
+                <td className="px-2 py-1 text-gray-700">{job.job_type}</td>
+                <td className="px-2 py-1">
+                  <span
+                    className={`rounded px-1.5 py-0.5 ${STATUS_CLASS[job.status] ?? "text-gray-700 bg-gray-100"}`}
+                    title={job.last_error ?? `attempts ${job.attempts}/${job.max_attempts}`}
+                  >
+                    {job.status}
+                  </span>
+                </td>
+                <td className="px-2 py-1 text-gray-700">{formatDuration(computeQueueMs(job, nowMs))}</td>
+                <td className="px-2 py-1 text-gray-700">{formatDuration(computeRunMs(job, nowMs))}</td>
+                <td className="px-2 py-1 text-gray-700">{formatDuration(computeTotalMs(job, nowMs))}</td>
+                <td className="px-2 py-1">
+                  <div className="flex gap-1">
+                    {job.status === "failed" && (
+                      <button
+                        onClick={() => rerunJob(job.id)}
+                        disabled={actioning.has(job.id)}
+                        className="rounded border border-blue-300 px-1.5 py-0.5 text-[11px] text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                      >
+                        Rerun
+                      </button>
+                    )}
+                    <button
+                      onClick={() => archiveJob(job.id)}
+                      disabled={actioning.has(job.id)}
+                      className="rounded border border-gray-300 px-1.5 py-0.5 text-[11px] text-gray-700 hover:bg-gray-100 disabled:opacity-50"
+                    >
+                      Archive
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/OrdersSideTable.tsx
+++ b/frontend/src/components/OrdersSideTable.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from "react";
+
+interface OrderRow {
+  id: number;
+  symbol: string;
+  side: string;
+  quantity: number;
+  status: string;
+  filled_quantity: number;
+  avg_fill_price: number | null;
+  created_at: string;
+  submitted_at: string | null;
+  completed_at: string | null;
+}
+
+const STATUS_CLASS: Record<string, string> = {
+  queued: "text-yellow-700 bg-yellow-100",
+  submitted: "text-blue-700 bg-blue-100",
+  partially_filled: "text-indigo-700 bg-indigo-100",
+  filled: "text-green-700 bg-green-100",
+  cancelled: "text-gray-700 bg-gray-200",
+  rejected: "text-red-700 bg-red-100",
+  failed: "text-red-700 bg-red-100",
+};
+
+function parseTime(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null) return "—";
+  const seconds = Math.max(0, Math.floor(ms / 1000));
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const remSeconds = seconds % 60;
+  if (minutes < 60) return `${minutes}m ${remSeconds}s`;
+  const hours = Math.floor(minutes / 60);
+  const remMinutes = minutes % 60;
+  return `${hours}h ${remMinutes}m`;
+}
+
+function computeQueueMs(order: OrderRow, nowMs: number): number {
+  const createdMs = parseTime(order.created_at) ?? nowMs;
+  const submittedMs = parseTime(order.submitted_at);
+  return (submittedMs ?? nowMs) - createdMs;
+}
+
+function computeRunMs(order: OrderRow, nowMs: number): number | null {
+  const submittedMs = parseTime(order.submitted_at);
+  if (submittedMs === null) return null;
+  const completedMs = parseTime(order.completed_at);
+  return (completedMs ?? nowMs) - submittedMs;
+}
+
+function computeTotalMs(order: OrderRow, nowMs: number): number {
+  const createdMs = parseTime(order.created_at) ?? nowMs;
+  const completedMs = parseTime(order.completed_at);
+  return (completedMs ?? nowMs) - createdMs;
+}
+
+export default function OrdersSideTable() {
+  const [orders, setOrders] = useState<OrderRow[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [nowMs, setNowMs] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    let active = true;
+
+    const load = () => {
+      fetch("http://localhost:8000/api/v1/orders")
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((rows: OrderRow[]) => {
+          if (!active) return;
+          setOrders(rows.slice(0, 20));
+          setError(null);
+        })
+        .catch((err: Error) => {
+          if (!active) return;
+          setError(err.message);
+        });
+    };
+
+    load();
+    const timer = window.setInterval(load, 2500);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    const timer = window.setInterval(() => setNowMs(Date.now()), 1000);
+    return () => window.clearInterval(timer);
+  }, []);
+
+  return (
+    <div className="min-w-[460px] rounded border border-gray-300 bg-white p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-gray-900">Orders</h3>
+        <span className="text-xs text-gray-500">Auto-refresh 2.5s</span>
+      </div>
+
+      {error && <p className="mb-2 text-xs text-red-600">Error: {error}</p>}
+
+      <div className="max-h-[280px] overflow-auto">
+        <table className="min-w-full border-collapse text-xs">
+          <thead>
+            <tr className="bg-gray-100 text-left">
+              <th className="px-2 py-1 font-semibold text-gray-700">ID</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Order</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Status</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Queue</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Run</th>
+              <th className="px-2 py-1 font-semibold text-gray-700">Total</th>
+            </tr>
+          </thead>
+          <tbody>
+            {orders.length === 0 && (
+              <tr>
+                <td className="px-2 py-2 text-gray-500" colSpan={6}>
+                  No orders yet.
+                </td>
+              </tr>
+            )}
+            {orders.map((order) => (
+              <tr key={order.id} className="border-b border-gray-200 align-top">
+                <td className="px-2 py-1 font-mono text-gray-800">{order.id}</td>
+                <td className="px-2 py-1 text-gray-700">
+                  {order.side} {order.quantity} {order.symbol}
+                </td>
+                <td className="px-2 py-1">
+                  <span
+                    className={`rounded px-1.5 py-0.5 ${STATUS_CLASS[order.status] ?? "text-gray-700 bg-gray-100"}`}
+                    title={`filled ${order.filled_quantity} avg ${order.avg_fill_price ?? "n/a"}`}
+                  >
+                    {order.status}
+                  </span>
+                </td>
+                <td className="px-2 py-1 text-gray-700">{formatDuration(computeQueueMs(order, nowMs))}</td>
+                <td className="px-2 py-1 text-gray-700">{formatDuration(computeRunMs(order, nowMs))}</td>
+                <td className="px-2 py-1 text-gray-700">{formatDuration(computeTotalMs(order, nowMs))}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/OrdersTable.tsx
+++ b/frontend/src/components/OrdersTable.tsx
@@ -1,0 +1,104 @@
+import { useEffect, useState } from "react";
+
+interface Order {
+  id: number;
+  account_id: number;
+  account_alias: string | null;
+  symbol: string;
+  sec_type: string;
+  side: string;
+  quantity: number;
+  status: string;
+  contract_month: string | null;
+  local_symbol: string | null;
+  ib_order_id: number | null;
+  filled_quantity: number;
+  avg_fill_price: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+const COLUMNS: { key: keyof Order; label: string }[] = [
+  { key: "id", label: "Order ID" },
+  { key: "account_alias", label: "Account" },
+  { key: "symbol", label: "Symbol" },
+  { key: "sec_type", label: "Sec Type" },
+  { key: "side", label: "Side" },
+  { key: "quantity", label: "Qty" },
+  { key: "status", label: "Status" },
+  { key: "contract_month", label: "Contract Month" },
+  { key: "local_symbol", label: "Local Symbol" },
+  { key: "ib_order_id", label: "IB Order ID" },
+  { key: "filled_quantity", label: "Filled Qty" },
+  { key: "avg_fill_price", label: "Avg Fill Px" },
+  { key: "created_at", label: "Created At" },
+  { key: "updated_at", label: "Updated At" },
+];
+
+export default function OrdersTable() {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    const load = () => {
+      fetch("http://localhost:8000/api/v1/orders")
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((data: Order[]) => {
+          if (!active) return;
+          setOrders(data);
+          setError(null);
+        })
+        .catch((err: Error) => {
+          if (!active) return;
+          setError(err.message);
+        })
+        .finally(() => {
+          if (active) setLoading(false);
+        });
+    };
+
+    load();
+    const timer = window.setInterval(load, 3000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  if (loading) return <p className="text-gray-500">Loading orders...</p>;
+  if (error) return <p className="text-red-600">Error: {error}</p>;
+  if (orders.length === 0) return <p className="text-gray-500">No orders found.</p>;
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full border-collapse text-sm">
+        <thead>
+          <tr className="bg-gray-100 text-left">
+            {COLUMNS.map((col) => (
+              <th key={col.key} className="px-3 py-2 font-semibold text-gray-700 whitespace-nowrap">
+                {col.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {orders.map((order) => (
+            <tr key={order.id} className="border-b border-gray-200 hover:bg-gray-50">
+              {COLUMNS.map((col) => (
+                <td key={col.key} className="px-3 py-2 whitespace-nowrap">
+                  {order[col.key] ?? "—"}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/OrdersTable.tsx
+++ b/frontend/src/components/OrdersTable.tsx
@@ -39,6 +39,7 @@ export default function OrdersTable() {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [actioning, setActioning] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     let active = true;
@@ -71,6 +72,30 @@ export default function OrdersTable() {
     };
   }, []);
 
+  function cancelOrder(orderId: number) {
+    setActioning((prev) => {
+      const next = new Set(prev);
+      next.add(orderId);
+      return next;
+    });
+    fetch(`http://localhost:8000/api/v1/orders/${orderId}/cancel`, { method: "POST" })
+      .then(async (res) => {
+        if (!res.ok) throw new Error(await res.text());
+        return res.json();
+      })
+      .then((updated: Order) => {
+        setOrders((prev) => prev.map((row) => (row.id === updated.id ? updated : row)));
+      })
+      .catch((err: Error) => setError(err.message))
+      .finally(() => {
+        setActioning((prev) => {
+          const next = new Set(prev);
+          next.delete(orderId);
+          return next;
+        });
+      });
+  }
+
   if (loading) return <p className="text-gray-500">Loading orders...</p>;
   if (error) return <p className="text-red-600">Error: {error}</p>;
   if (orders.length === 0) return <p className="text-gray-500">No orders found.</p>;
@@ -85,6 +110,7 @@ export default function OrdersTable() {
                 {col.label}
               </th>
             ))}
+            <th className="px-3 py-2 font-semibold text-gray-700 whitespace-nowrap">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -95,6 +121,17 @@ export default function OrdersTable() {
                   {order[col.key] ?? "—"}
                 </td>
               ))}
+              <td className="px-3 py-2 whitespace-nowrap">
+                {order.status === "queued" && (
+                  <button
+                    onClick={() => cancelOrder(order.id)}
+                    disabled={actioning.has(order.id)}
+                    className="rounded border border-red-300 px-2 py-1 text-xs text-red-700 hover:bg-red-50 disabled:opacity-50"
+                  >
+                    Cancel
+                  </button>
+                )}
+              </td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/TradebotChat.tsx
+++ b/frontend/src/components/TradebotChat.tsx
@@ -63,8 +63,8 @@ export default function TradebotChat() {
   };
 
   return (
-    <div className="w-full max-w-7xl">
-      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.7fr)_minmax(460px,1.1fr)]">
+    <div className="w-full">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.8fr)_minmax(400px,1.2fr)_minmax(420px,1.3fr)]">
         <div className="min-w-0">
           <div className="mb-3 flex flex-wrap gap-2">
             <button
@@ -136,11 +136,8 @@ export default function TradebotChat() {
           <p className="mt-2 text-xs text-gray-500">Status: {status}</p>
           {error && <p className="mt-1 text-xs text-red-600">Error: {error.message}</p>}
         </div>
-
-        <div className="space-y-4">
-          <JobsTable />
-          <OrdersSideTable />
-        </div>
+        <JobsTable />
+        <OrdersSideTable />
       </div>
     </div>
   );

--- a/frontend/src/components/TradebotChat.tsx
+++ b/frontend/src/components/TradebotChat.tsx
@@ -1,0 +1,122 @@
+import { useMemo, useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import { TextStreamChatTransport, type UIMessage } from "ai";
+import JobsTable from "./JobsTable";
+import OrdersSideTable from "./OrdersSideTable";
+
+const QUICK_PROMPTS = [
+  "Show me current positions",
+  "Buy 1 more CL contracts",
+  "Status for latest orders",
+];
+const POSITION_SYNC_PROMPT = "Refresh positions now";
+
+function messageText(message: UIMessage): string {
+  const parts = message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text.trim())
+    .filter((text) => text.length > 0);
+  return parts.join("\n");
+}
+
+export default function TradebotChat() {
+  const transport = useMemo(
+    () =>
+      new TextStreamChatTransport({
+        api: "http://localhost:8000/api/v1/tradebot/chat",
+      }),
+    [],
+  );
+  const { messages, sendMessage, status, error, stop } = useChat({ transport });
+  const [input, setInput] = useState("");
+
+  const submit = async (text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    await sendMessage({ text: trimmed });
+    setInput("");
+  };
+
+  return (
+    <div className="w-full max-w-7xl">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1.7fr)_minmax(460px,1.1fr)]">
+        <div className="min-w-0">
+          <div className="mb-3 flex flex-wrap gap-2">
+            <button
+              onClick={() => void submit(POSITION_SYNC_PROMPT)}
+              disabled={status === "submitted" || status === "streaming"}
+              className="rounded bg-blue-600 px-3 py-1 text-xs text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              Kickoff Position Sync
+            </button>
+            {QUICK_PROMPTS.map((prompt) => (
+              <button
+                key={prompt}
+                onClick={() => setInput(prompt)}
+                className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-700 hover:bg-gray-100"
+              >
+                {prompt}
+              </button>
+            ))}
+          </div>
+
+          <div className="h-[460px] overflow-y-auto rounded border border-gray-300 bg-white p-4">
+            {messages.length === 0 && (
+              <p className="text-sm text-gray-500">
+                Ask about positions, queue CL orders, or check order progress.
+              </p>
+            )}
+            <div className="space-y-3">
+              {messages.map((message) => (
+                <div key={message.id} className="rounded border border-gray-200 p-3 text-sm">
+                  <p className="mb-1 text-xs uppercase tracking-wide text-gray-500">{message.role}</p>
+                  <pre className="whitespace-pre-wrap font-sans text-gray-900">{messageText(message) || "…"}</pre>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <form
+            className="mt-3 flex gap-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void submit(input);
+            }}
+          >
+            <input
+              type="text"
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              placeholder="e.g. buy 1 more CL contracts account 1"
+              className="flex-1 rounded border border-gray-300 px-3 py-2 text-sm"
+            />
+            <button
+              type="submit"
+              disabled={status === "submitted" || status === "streaming"}
+              className="rounded bg-black px-4 py-2 text-sm text-white disabled:opacity-50"
+            >
+              Send
+            </button>
+            {(status === "submitted" || status === "streaming") && (
+              <button
+                type="button"
+                onClick={() => stop()}
+                className="rounded border border-gray-300 px-3 py-2 text-sm text-gray-700"
+              >
+                Stop
+              </button>
+            )}
+          </form>
+
+          <p className="mt-2 text-xs text-gray-500">Status: {status}</p>
+          {error && <p className="mt-1 text-xs text-red-600">Error: {error.message}</p>}
+        </div>
+
+        <div className="space-y-4">
+          <JobsTable />
+          <OrdersSideTable />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/WorkerStatusLights.tsx
+++ b/frontend/src/components/WorkerStatusLights.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+
+type LightColor = "green" | "yellow" | "red";
+
+interface WorkerStatus {
+  worker_type: string;
+  light: LightColor;
+  status: string;
+  heartbeat_at: string | null;
+  seconds_since_heartbeat: number | null;
+  details: string | null;
+}
+
+const KNOWN_WORKERS = ["orders", "jobs"] as const;
+
+const LIGHT_CLASS: Record<LightColor, string> = {
+  green: "bg-green-500",
+  yellow: "bg-yellow-500",
+  red: "bg-red-500",
+};
+
+function fallbackStatus(workerType: string): WorkerStatus {
+  return {
+    worker_type: workerType,
+    light: "red",
+    status: "unknown",
+    heartbeat_at: null,
+    seconds_since_heartbeat: null,
+    details: "No data",
+  };
+}
+
+function formatAge(seconds: number | null): string {
+  if (seconds === null) return "n/a";
+  if (seconds < 60) return `${Math.round(seconds)}s`;
+  return `${Math.round(seconds / 60)}m`;
+}
+
+export default function WorkerStatusLights() {
+  const [statusMap, setStatusMap] = useState<Record<string, WorkerStatus>>({});
+
+  useEffect(() => {
+    let active = true;
+
+    const load = () => {
+      fetch("http://localhost:8000/api/v1/workers/status")
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((rows: WorkerStatus[]) => {
+          if (!active) return;
+          const next: Record<string, WorkerStatus> = {};
+          rows.forEach((row) => {
+            next[row.worker_type] = row;
+          });
+          setStatusMap(next);
+        })
+        .catch(() => {
+          if (!active) return;
+          const next: Record<string, WorkerStatus> = {};
+          KNOWN_WORKERS.forEach((workerType) => {
+            next[workerType] = fallbackStatus(workerType);
+          });
+          setStatusMap(next);
+        });
+    };
+
+    load();
+    const timer = window.setInterval(load, 4000);
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+
+  return (
+    <div className="ml-auto flex items-center gap-4">
+      {KNOWN_WORKERS.map((workerType) => {
+        const row = statusMap[workerType] ?? fallbackStatus(workerType);
+        const label = workerType === "orders" ? "Worker Orders" : "Worker Jobs";
+        return (
+          <div
+            key={workerType}
+            className="inline-flex items-center gap-2 text-xs text-gray-600"
+            title={`${row.status} (${formatAge(row.seconds_since_heartbeat)} ago) ${row.details ?? ""}`}
+          >
+            <span className={`inline-block h-2.5 w-2.5 rounded-full ${LIGHT_CLASS[row.light]}`} />
+            <span>{label}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/scripts/download_positions.py
+++ b/scripts/download_positions.py
@@ -38,7 +38,13 @@ def main():
 
     print(f"Connecting to TWS at {host}:{port} ...")
     try:
-        saved_count = sync_positions_once(engine=engine, host=host, port=port, client_id=client_id)
+        saved_count = sync_positions_once(
+            engine=engine,
+            host=host,
+            port=port,
+            client_id=client_id,
+            connect_timeout_seconds=20.0,
+        )
         print(f"Saved {saved_count} position(s) to database.")
     except Exception as e:
         print(f"Error: {e}")

--- a/scripts/download_positions.py
+++ b/scripts/download_positions.py
@@ -7,16 +7,12 @@ Usage:
 
 import argparse
 import os
-from datetime import datetime, timezone
 
 from dotenv import load_dotenv
-from ib_async import IB
-from sqlalchemy import inspect, select
-from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import Session
 
 from src.db import get_engine
-from src.models import Account, Position
+from src.utils.env_vars import get_int_env
+from src.services.position_sync import check_positions_tables_ready, sync_positions_once
 
 
 def load_env(env_name: str) -> None:
@@ -24,39 +20,6 @@ def load_env(env_name: str) -> None:
     if not os.path.exists(env_file):
         raise FileNotFoundError(f"{env_file} not found")
     load_dotenv(env_file)
-
-
-def check_db_ready(engine):
-    """Check that the database and positions table exist."""
-    try:
-        inspector = inspect(engine)
-        tables = inspector.get_table_names()
-        for required in ("positions", "accounts"):
-            if required not in tables:
-                print(f"Error: '{required}' table does not exist.")
-                print("Run: task migrate")
-                raise SystemExit(1)
-    except Exception as e:
-        if "does not exist" in str(e) or "could not connect" in str(e):
-            print(f"Error: Cannot connect to database: {e}")
-            print("Run: task migrate")
-            raise SystemExit(1)
-        raise
-
-
-def get_or_create_accounts(session: Session, account_strings: set[str]) -> dict[str, int]:
-    """Get or create Account rows, return {account_str: account_id} mapping."""
-    lookup = {}
-    for acct_str in account_strings:
-        row = session.execute(
-            select(Account).where(Account.account == acct_str)
-        ).scalar_one_or_none()
-        if row is None:
-            row = Account(account=acct_str)
-            session.add(row)
-            session.flush()
-        lookup[acct_str] = row.id
-    return lookup
 
 
 def main():
@@ -67,82 +30,19 @@ def main():
     load_env(args.env)
 
     engine = get_engine()
-    check_db_ready(engine)
+    check_positions_tables_ready(engine)
 
     host = "127.0.0.1"
-    port = int(os.environ.get("BROKER_TWS_PORT", "7497"))
+    port = get_int_env("BROKER_TWS_PORT", 7497)
+    client_id = 2
 
     print(f"Connecting to TWS at {host}:{port} ...")
-    ib = IB()
     try:
-        ib.connect(host, port, clientId=2)
-        print("Connected to TWS.")
-
-        positions = ib.positions()
-        print(f"Fetched {len(positions)} position(s) from TWS.")
-
-        if not positions:
-            print("No positions to save.")
-            return
-
-        now = datetime.now(timezone.utc)
-
-        with Session(engine) as session:
-            unique_accounts = {pos.account for pos in positions}
-            account_lookup = get_or_create_accounts(session, unique_accounts)
-
-            for pos in positions:
-                contract = pos.contract
-                account_id = account_lookup[pos.account]
-                stmt = insert(Position).values(
-                    account_id=account_id,
-                    con_id=contract.conId,
-                    symbol=contract.symbol,
-                    sec_type=contract.secType,
-                    exchange=contract.exchange,
-                    primary_exchange=contract.primaryExchange,
-                    currency=contract.currency,
-                    local_symbol=contract.localSymbol,
-                    trading_class=contract.tradingClass,
-                    last_trade_date=contract.lastTradeDateOrContractMonth,
-                    strike=contract.strike,
-                    right=contract.right,
-                    multiplier=contract.multiplier,
-                    position=pos.position,
-                    avg_cost=pos.avgCost,
-                    fetched_at=now,
-                ).on_conflict_do_update(
-                    constraint="uq_account_id_con_id",
-                    set_={
-                        "symbol": contract.symbol,
-                        "sec_type": contract.secType,
-                        "exchange": contract.exchange,
-                        "primary_exchange": contract.primaryExchange,
-                        "currency": contract.currency,
-                        "local_symbol": contract.localSymbol,
-                        "trading_class": contract.tradingClass,
-                        "last_trade_date": contract.lastTradeDateOrContractMonth,
-                        "strike": contract.strike,
-                        "right": contract.right,
-                        "multiplier": contract.multiplier,
-                        "position": pos.position,
-                        "avg_cost": pos.avgCost,
-                        "fetched_at": now,
-                    },
-                )
-                session.execute(stmt)
-
-            session.commit()
-
-        print(f"Saved {len(positions)} position(s) to database.")
-
+        saved_count = sync_positions_once(engine=engine, host=host, port=port, client_id=client_id)
+        print(f"Saved {saved_count} position(s) to database.")
     except Exception as e:
         print(f"Error: {e}")
         raise SystemExit(1)
-    finally:
-        if ib.isConnected():
-            ib.disconnect()
-            print("Disconnected from TWS.")
 
 
 if __name__ == "__main__":

--- a/scripts/execute_cl_buy_or_sell_continous_market.py
+++ b/scripts/execute_cl_buy_or_sell_continous_market.py
@@ -12,14 +12,18 @@ Usage:
 from __future__ import annotations
 
 import argparse
-import datetime as dt
 import math
 import os
 import time
 
 from dotenv import load_dotenv
-from ib_async import Contract, Future, IB, MarketOrder, Order, OrderState, Ticker, Trade
+from ib_async import Contract, IB, MarketOrder, Order, OrderState, Ticker, Trade
 
+from src.services.cl_contracts import (
+    format_contract_month,
+    select_front_month_contract,
+)
+from src.utils.env_vars import get_int_env
 from src.utils.ibkr_account import mask_ibkr_account
 
 
@@ -83,43 +87,10 @@ def parse_float(value: str | float | int | None) -> float | None:
     return parsed
 
 
-def parse_contract_expiry(last_trade_or_month: str) -> dt.date | None:
-    value = (last_trade_or_month or "").strip()
-    if len(value) >= 8 and value[:8].isdigit():
-        try:
-            return dt.datetime.strptime(value[:8], "%Y%m%d").date()
-        except ValueError:
-            return None
-    if len(value) >= 6 and value[:6].isdigit():
-        try:
-            year = int(value[:4])
-            month = int(value[4:6])
-            if month == 12:
-                next_month = dt.date(year + 1, 1, 1)
-            else:
-                next_month = dt.date(year, month + 1, 1)
-            return next_month - dt.timedelta(days=1)
-        except ValueError:
-            return None
-    return None
-
-
 def format_money(value: float | None) -> str:
     if value is None:
         return "N/A"
     return f"${value:,.2f}"
-
-
-def format_contract_month(contract: Contract) -> str:
-    raw_value = (contract.lastTradeDateOrContractMonth or "").strip()
-    if len(raw_value) >= 6 and raw_value[:6].isdigit():
-        return f"{raw_value[:4]}-{raw_value[4:6]}"
-
-    expiry = parse_contract_expiry(raw_value)
-    if expiry is not None:
-        return expiry.strftime("%Y-%m")
-
-    return "unknown"
 
 
 def choose_account(ib: IB, requested_account: str | None) -> str:
@@ -165,35 +136,6 @@ def get_what_if_state(ib: IB, contract: Contract, order: Order) -> OrderState:
     return response
 
 
-def select_front_month_contract(ib: IB) -> Contract:
-    contract_details = ib.reqContractDetails(Future("CL", exchange="NYMEX", currency="USD"))
-    if not contract_details:
-        raise RuntimeError("No CL futures contract details returned from IBKR")
-
-    today = dt.date.today()
-    candidates: list[tuple[dt.date, Contract]] = []
-    for detail in contract_details:
-        contract = detail.contract
-        if contract is None:
-            continue
-        expiry = parse_contract_expiry(contract.lastTradeDateOrContractMonth)
-        if contract.secType != "FUT" or expiry is None or expiry < today:
-            continue
-        candidates.append((expiry, contract))
-
-    if not candidates:
-        raise RuntimeError("No non-expired CL futures contracts found")
-
-    candidates.sort(key=lambda item: item[0])
-    front_month_contract = candidates[0][1]
-    qualified_contracts = ib.qualifyContracts(front_month_contract)
-    if len(qualified_contracts) != 1:
-        raise RuntimeError(
-            f"Expected exactly one qualified front-month contract, got {len(qualified_contracts)}"
-        )
-    return qualified_contracts[0]
-
-
 def print_trade_snapshot(trade: Trade) -> None:
     print(
         "Trade status:"
@@ -221,7 +163,7 @@ def main() -> int:
         raise SystemExit("--qty must be >= 1")
 
     load_env(args.env)
-    port = args.port or int(os.environ.get("BROKER_TWS_PORT", "7497"))
+    port = args.port or get_int_env("BROKER_TWS_PORT", 7497)
 
     action = args.side.upper()
 
@@ -234,7 +176,7 @@ def main() -> int:
         print(f"Using account: {mask_ibkr_account(account)}")
 
         qualified_contract = select_front_month_contract(ib)
-        contract_month = format_contract_month(qualified_contract)
+        contract_month = format_contract_month(qualified_contract) or "unknown"
         contract_expiry = qualified_contract.lastTradeDateOrContractMonth
 
         print("Order intent:")

--- a/scripts/test_tws_connection.py
+++ b/scripts/test_tws_connection.py
@@ -15,6 +15,8 @@ import os
 from dotenv import load_dotenv
 from ib_async import IB
 
+from src.utils.env_vars import get_int_env
+
 
 def load_env(env_name: str) -> None:
     env_file = f".env.{env_name}"
@@ -31,7 +33,7 @@ def main():
     load_env(args.env)
 
     host = "127.0.0.1"
-    port = int(os.environ.get("BROKER_TWS_PORT", "7497"))
+    port = get_int_env("BROKER_TWS_PORT", 7497)
 
     print(f"Connecting to TWS at {host}:{port} ...")
 

--- a/scripts/work_jobs.py
+++ b/scripts/work_jobs.py
@@ -62,6 +62,7 @@ def handle_positions_sync(job: Job, engine: Engine) -> dict:
     host = str(payload.get("host") or "127.0.0.1")
     port_raw = payload.get("port")
     client_id_raw = payload.get("client_id")
+    connect_timeout_raw = payload.get("connect_timeout_seconds")
 
     if isinstance(port_raw, int):
         port = port_raw
@@ -75,17 +76,24 @@ def handle_positions_sync(job: Job, engine: Engine) -> dict:
     else:
         client_id = 31
 
+    if isinstance(connect_timeout_raw, (int, float)):
+        connect_timeout_seconds = float(connect_timeout_raw)
+    else:
+        connect_timeout_seconds = 20.0
+
     fetched_positions_count = sync_positions_once(
         engine=engine,
         host=host,
         port=port,
         client_id=client_id,
+        connect_timeout_seconds=connect_timeout_seconds,
     )
     return {
         "fetched_positions_count": fetched_positions_count,
         "host": host,
         "port": port,
         "client_id": client_id,
+        "connect_timeout_seconds": connect_timeout_seconds,
     }
 
 

--- a/scripts/work_jobs.py
+++ b/scripts/work_jobs.py
@@ -1,0 +1,174 @@
+"""
+Generic jobs worker.
+
+Polls queued jobs and dispatches handlers by `job_type`.
+Initial handler: `positions.sync`
+
+Usage:
+  uv run python scripts/work_jobs.py --env dev
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from collections.abc import Callable
+
+from dotenv import load_dotenv
+from sqlalchemy import inspect
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from src.db import get_engine
+from src.models import Job
+from src.services.jobs import (
+    JOB_TYPE_POSITIONS_SYNC,
+    claim_next_job,
+    complete_job,
+    fail_or_retry_job,
+)
+from src.services.position_sync import check_positions_tables_ready, sync_positions_once
+from src.services.worker_heartbeat import WORKER_TYPE_JOBS, upsert_worker_heartbeat
+from src.utils.env_vars import get_int_env
+
+
+def load_env(env_name: str) -> None:
+    env_file = f".env.{env_name}"
+    if not os.path.exists(env_file):
+        raise FileNotFoundError(f"{env_file} not found")
+    load_dotenv(env_file)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Process queued jobs.")
+    parser.add_argument("--env", choices=["dev", "prod"], default="dev")
+    parser.add_argument("--poll-seconds", type=float, default=2.0)
+    parser.add_argument("--once", action="store_true", help="Process one queue pass and exit.")
+    return parser.parse_args()
+
+
+def check_db_ready() -> None:
+    engine = get_engine()
+    check_positions_tables_ready(engine)
+    tables = inspect(engine).get_table_names()
+    for required in ("jobs", "worker_heartbeats"):
+        if required not in tables:
+            raise SystemExit(f"Missing '{required}' table. Run: task migrate")
+
+
+def handle_positions_sync(job: Job, engine: Engine) -> dict:
+    payload = job.payload or {}
+    host = str(payload.get("host") or "127.0.0.1")
+    port_raw = payload.get("port")
+    client_id_raw = payload.get("client_id")
+
+    if isinstance(port_raw, int):
+        port = port_raw
+    else:
+        port = get_int_env("BROKER_TWS_PORT")
+    if port is None:
+        raise RuntimeError("BROKER_TWS_PORT is not set and no port was provided in job payload.")
+
+    if isinstance(client_id_raw, int):
+        client_id = client_id_raw
+    else:
+        client_id = 31
+
+    fetched_positions_count = sync_positions_once(
+        engine=engine,
+        host=host,
+        port=port,
+        client_id=client_id,
+    )
+    return {
+        "fetched_positions_count": fetched_positions_count,
+        "host": host,
+        "port": port,
+        "client_id": client_id,
+    }
+
+
+def get_handler(job_type: str) -> Callable[[Job, Engine], dict] | None:
+    handlers: dict[str, Callable[[Job, Engine], dict]] = {
+        JOB_TYPE_POSITIONS_SYNC: handle_positions_sync,
+    }
+    return handlers.get(job_type)
+
+
+def main() -> int:
+    args = parse_args()
+    load_env(args.env)
+    check_db_ready()
+
+    engine = get_engine()
+    upsert_worker_heartbeat(
+        engine,
+        WORKER_TYPE_JOBS,
+        status="starting",
+        details="worker boot",
+    )
+
+    try:
+        while True:
+            processed = 0
+            while True:
+                with Session(engine) as session:
+                    claimed_job = claim_next_job(session)
+                    if claimed_job is None:
+                        break
+                    job_id = claimed_job.id
+                    session.commit()
+
+                processed += 1
+                with Session(engine) as session:
+                    job = session.get(Job, job_id)
+                    if job is None:
+                        session.rollback()
+                        continue
+
+                    handler = get_handler(job.job_type)
+                    if handler is None:
+                        fail_or_retry_job(
+                            session,
+                            job,
+                            f"Unsupported job_type '{job.job_type}'",
+                            retry_delay_seconds=0,
+                        )
+                        session.commit()
+                        continue
+
+                    try:
+                        result = handler(job, engine)
+                        complete_job(session, job, result)
+                    except Exception as exc:
+                        fail_or_retry_job(session, job, str(exc))
+                    session.commit()
+
+            upsert_worker_heartbeat(
+                engine,
+                WORKER_TYPE_JOBS,
+                status="running",
+                details=f"processed={processed}",
+            )
+
+            if args.once:
+                print(f"Processed {processed} job(s).")
+                return 0
+
+            if processed == 0:
+                time.sleep(args.poll_seconds)
+    finally:
+        try:
+            upsert_worker_heartbeat(
+                engine,
+                WORKER_TYPE_JOBS,
+                status="stopped",
+                details="worker exiting",
+            )
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/work_order_queue.py
+++ b/scripts/work_order_queue.py
@@ -1,0 +1,263 @@
+"""
+Order queue worker.
+
+Polls queued orders, submits them to TWS/Gateway, and stores status/fill progress.
+
+Usage:
+  uv run python scripts/work_order_queue.py --env dev
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import time
+from typing import Any
+
+from dotenv import load_dotenv
+from ib_async import Contract, IB, MarketOrder, Trade
+from sqlalchemy import inspect, select
+from sqlalchemy.orm import Session
+
+from src.db import get_engine
+from src.models import Account, Order
+from src.services.cl_contracts import select_front_month_contract
+from src.services.order_queue import apply_order_progress, append_order_event, now_utc
+from src.services.worker_heartbeat import WORKER_TYPE_ORDERS, upsert_worker_heartbeat
+from src.utils.env_vars import get_int_env
+from src.utils.ibkr_account import mask_ibkr_account
+
+
+def load_env(env_name: str) -> None:
+    env_file = f".env.{env_name}"
+    if not os.path.exists(env_file):
+        raise FileNotFoundError(f"{env_file} not found")
+    load_dotenv(env_file)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Process queued orders and execute in TWS.")
+    parser.add_argument("--env", choices=["dev", "prod"], default="dev")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=None)
+    parser.add_argument("--client-id", type=int, default=30)
+    parser.add_argument("--poll-seconds", type=float, default=2.0)
+    parser.add_argument("--order-timeout-seconds", type=float, default=45.0)
+    parser.add_argument("--once", action="store_true", help="Process one queue pass and exit.")
+    return parser.parse_args()
+
+
+def check_db_ready() -> None:
+    inspector = inspect(get_engine())
+    tables = inspector.get_table_names()
+    for required in ("accounts", "orders", "order_events", "worker_heartbeats"):
+        if required not in tables:
+            raise SystemExit(f"Missing '{required}' table. Run: task migrate")
+
+
+def parse_float(value: str | float | int | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def get_or_qualify_contract(ib: IB, order: Order) -> Contract:
+    if order.con_id:
+        contract_kwargs: dict[str, Any] = {
+            "conId": order.con_id,
+            "symbol": order.symbol,
+            "secType": order.sec_type,
+            "exchange": order.exchange,
+            "currency": order.currency,
+        }
+        if order.local_symbol is not None:
+            contract_kwargs["localSymbol"] = order.local_symbol
+        if order.trading_class is not None:
+            contract_kwargs["tradingClass"] = order.trading_class
+        contract = Contract(**contract_kwargs)
+        qualified = ib.qualifyContracts(contract)
+        if len(qualified) == 1:
+            return qualified[0]
+
+    if order.symbol == "CL":
+        return select_front_month_contract(ib)
+
+    fallback = Contract(
+        symbol=order.symbol,
+        secType=order.sec_type,
+        exchange=order.exchange,
+        currency=order.currency,
+    )
+    qualified = ib.qualifyContracts(fallback)
+    if len(qualified) != 1:
+        raise RuntimeError(f"Could not qualify contract for order {order.id}")
+    return qualified[0]
+
+
+def sync_trade_progress(session: Session, order: Order, trade: Trade, event_type: str) -> None:
+    changed = apply_order_progress(
+        order=order,
+        ib_status=trade.orderStatus.status,
+        filled_quantity=trade.filled(),
+        avg_fill_price=parse_float(trade.orderStatus.avgFillPrice),
+        ib_order_id=trade.order.orderId,
+        ib_perm_id=trade.order.permId,
+    )
+    if changed:
+        append_order_event(
+            session,
+            order,
+            event_type=event_type,
+            message=(
+                f"IB status={trade.orderStatus.status}, filled={trade.filled()}, "
+                f"remaining={trade.remaining()}, avgFill={trade.orderStatus.avgFillPrice}"
+            ),
+        )
+
+
+def process_order(
+    ib: IB,
+    session: Session,
+    order: Order,
+    timeout_seconds: float,
+) -> None:
+    account = session.get(Account, order.account_id)
+    if account is None:
+        order.status = "failed"
+        order.last_error = f"Missing account row for account_id={order.account_id}"
+        order.updated_at = now_utc()
+        append_order_event(session, order, "order_error", order.last_error or "Unknown error")
+        return
+
+    try:
+        contract = get_or_qualify_contract(ib, order)
+        order.con_id = contract.conId
+        order.local_symbol = contract.localSymbol
+        order.trading_class = contract.tradingClass
+        order.contract_expiry = contract.lastTradeDateOrContractMonth
+        order.updated_at = now_utc()
+        append_order_event(
+            session,
+            order,
+            "contract_qualified",
+            f"Qualified conId={contract.conId}, localSymbol={contract.localSymbol}",
+        )
+
+        tws_account = account.account
+        managed_accounts = ib.managedAccounts()
+        if tws_account not in managed_accounts:
+            masked = mask_ibkr_account(tws_account)
+            raise RuntimeError(f"Account {masked} is not managed by this IBKR session")
+
+        ib_order = MarketOrder(order.side, order.quantity)
+        ib_order.account = tws_account
+        ib_order.tif = order.tif
+
+        trade = ib.placeOrder(contract, ib_order)
+        order.submitted_at = now_utc()
+        sync_trade_progress(session, order, trade, event_type="order_submitted")
+        session.flush()
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline and not trade.isDone():
+            ib.waitOnUpdate(timeout=1.0)
+            sync_trade_progress(session, order, trade, event_type="order_progress")
+            session.flush()
+
+        sync_trade_progress(session, order, trade, event_type="order_final")
+        if trade.advancedError:
+            order.last_error = trade.advancedError
+            order.updated_at = now_utc()
+            append_order_event(session, order, "ib_advanced_error", trade.advancedError)
+    except Exception as exc:
+        order.status = "failed"
+        order.last_error = str(exc)
+        order.updated_at = now_utc()
+        if order.completed_at is None:
+            order.completed_at = now_utc()
+        append_order_event(session, order, "order_error", f"Worker error: {exc}")
+
+
+def run_worker(args: argparse.Namespace) -> int:
+    port = args.port if args.port is not None else get_int_env("BROKER_TWS_PORT")
+    if port is None:
+        raise SystemExit("BROKER_TWS_PORT is not set. Pass --port or set BROKER_TWS_PORT.")
+    engine = get_engine()
+    ib = IB()
+    upsert_worker_heartbeat(
+        engine,
+        WORKER_TYPE_ORDERS,
+        status="starting",
+        details=f"connecting to {args.host}:{port}",
+    )
+
+    try:
+        ib.connect(args.host, port, clientId=args.client_id)
+        print(f"Connected to TWS/Gateway at {args.host}:{port}.")
+        upsert_worker_heartbeat(
+            engine,
+            WORKER_TYPE_ORDERS,
+            status="running",
+            details=f"connected to {args.host}:{port}",
+        )
+
+        while True:
+            processed = 0
+            with Session(engine) as session:
+                stmt = (
+                    select(Order)
+                    .where(Order.status == "queued")
+                    .order_by(Order.created_at.asc())
+                    .limit(20)
+                )
+                orders = list(session.execute(stmt).scalars().all())
+                for order in orders:
+                    process_order(
+                        ib=ib,
+                        session=session,
+                        order=order,
+                        timeout_seconds=args.order_timeout_seconds,
+                    )
+                    processed += 1
+                session.commit()
+
+            upsert_worker_heartbeat(
+                engine,
+                WORKER_TYPE_ORDERS,
+                status="running",
+                details=f"processed={processed}, tws_connected={ib.isConnected()}",
+            )
+
+            if args.once:
+                print(f"Processed {processed} order(s).")
+                return 0
+
+            if processed == 0:
+                time.sleep(args.poll_seconds)
+    finally:
+        try:
+            upsert_worker_heartbeat(
+                engine,
+                WORKER_TYPE_ORDERS,
+                status="stopped",
+                details="worker exiting",
+            )
+        except Exception:
+            pass
+        if ib.isConnected():
+            ib.disconnect()
+            print("Disconnected from TWS/Gateway.")
+
+
+def main() -> int:
+    args = parse_args()
+    load_env(args.env)
+    check_db_ready()
+    return run_worker(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from src.api.routers import accounts, positions
+from src.api.routers import accounts, jobs, orders, positions, tradebot, workers
 
 load_dotenv()
 
@@ -19,3 +19,7 @@ app.add_middleware(
 
 app.include_router(accounts.router, prefix="/api/v1")
 app.include_router(positions.router, prefix="/api/v1")
+app.include_router(orders.router, prefix="/api/v1")
+app.include_router(jobs.router, prefix="/api/v1")
+app.include_router(tradebot.router, prefix="/api/v1")
+app.include_router(workers.router, prefix="/api/v1")

--- a/src/api/routers/jobs.py
+++ b/src/api/routers/jobs.py
@@ -1,0 +1,114 @@
+"""Jobs API router."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_db
+from src.models import Job
+from src.services.jobs import enqueue_job, now_utc
+
+router = APIRouter()
+
+
+class JobResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: int
+    job_type: str
+    status: str
+    payload: dict
+    result: dict | None
+    source: str
+    request_text: str | None
+    attempts: int
+    max_attempts: int
+    available_at: datetime
+    started_at: datetime | None
+    completed_at: datetime | None
+    archived_at: datetime | None
+    last_error: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+def to_job_response(job: Job) -> JobResponse:
+    return JobResponse(
+        id=job.id,
+        job_type=job.job_type,
+        status=job.status,
+        payload=job.payload,
+        result=job.result,
+        source=job.source,
+        request_text=job.request_text,
+        attempts=job.attempts,
+        max_attempts=job.max_attempts,
+        available_at=job.available_at,
+        started_at=job.started_at,
+        completed_at=job.completed_at,
+        archived_at=job.archived_at,
+        last_error=job.last_error,
+        created_at=job.created_at,
+        updated_at=job.updated_at,
+    )
+
+
+@router.get("/jobs", response_model=list[JobResponse])
+def list_jobs(
+    include_archived: bool = Query(default=False),
+    db: Session = Depends(get_db),
+) -> list[JobResponse]:
+    stmt = select(Job)
+    if not include_archived:
+        stmt = stmt.where(Job.archived_at.is_(None))
+    rows = db.execute(stmt.order_by(Job.created_at.desc())).scalars().all()
+    return [to_job_response(job) for job in rows]
+
+
+@router.get("/jobs/{job_id}", response_model=JobResponse)
+def get_job(job_id: int, db: Session = Depends(get_db)) -> JobResponse:
+    job = db.get(Job, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    return to_job_response(job)
+
+
+@router.post("/jobs/{job_id}/rerun", response_model=JobResponse, status_code=201)
+def rerun_job(job_id: int, db: Session = Depends(get_db)) -> JobResponse:
+    job = db.get(Job, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.status != "failed":
+        raise HTTPException(status_code=400, detail="Only failed jobs can be rerun")
+
+    rerun = enqueue_job(
+        session=db,
+        job_type=job.job_type,
+        payload=job.payload,
+        source=job.source,
+        request_text=job.request_text,
+        max_attempts=job.max_attempts,
+    )
+    now = now_utc()
+    job.archived_at = now
+    job.updated_at = now
+    db.commit()
+    db.refresh(rerun)
+    return to_job_response(rerun)
+
+
+@router.post("/jobs/{job_id}/archive", response_model=JobResponse)
+def archive_job(job_id: int, db: Session = Depends(get_db)) -> JobResponse:
+    job = db.get(Job, job_id)
+    if job is None:
+        raise HTTPException(status_code=404, detail="Job not found")
+    if job.archived_at is None:
+        now = now_utc()
+        job.archived_at = now
+        job.updated_at = now
+        db.commit()
+        db.refresh(job)
+    return to_job_response(job)

--- a/src/api/routers/orders.py
+++ b/src/api/routers/orders.py
@@ -1,0 +1,194 @@
+"""Orders API router."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_db
+from src.models import Account, Order, OrderEvent
+from src.services.order_queue import append_order_event, now_utc
+
+router = APIRouter()
+
+
+class OrderCreateRequest(BaseModel):
+    account_id: int
+    symbol: str = Field(..., min_length=1)
+    side: str = Field(..., pattern="^(BUY|SELL|buy|sell)$")
+    quantity: int = Field(..., ge=1)
+    sec_type: str = "FUT"
+    exchange: str = "NYMEX"
+    currency: str = "USD"
+    order_type: str = "MKT"
+    tif: str = "DAY"
+    source: str = "manual"
+    request_text: str | None = None
+
+
+class OrderResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: int
+    account_id: int
+    account_alias: str | None
+    symbol: str
+    sec_type: str
+    exchange: str
+    currency: str
+    side: str
+    quantity: int
+    order_type: str
+    tif: str
+    status: str
+    source: str
+    con_id: int | None
+    local_symbol: str | None
+    trading_class: str | None
+    contract_month: str | None
+    contract_expiry: str | None
+    ib_order_id: int | None
+    ib_perm_id: int | None
+    filled_quantity: float
+    avg_fill_price: float | None
+    last_error: str | None
+    request_text: str | None
+    submitted_at: datetime | None
+    completed_at: datetime | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class OrderEventResponse(BaseModel):
+    model_config = {"from_attributes": True}
+
+    id: int
+    order_id: int
+    event_type: str
+    message: str
+    status: str | None
+    filled_quantity: float | None
+    avg_fill_price: float | None
+    ib_order_id: int | None
+    created_at: datetime
+
+
+def to_order_response(order: Order, account: Account | None) -> OrderResponse:
+    alias = account.alias if account and account.alias else None
+    return OrderResponse(
+        id=order.id,
+        account_id=order.account_id,
+        account_alias=alias,
+        symbol=order.symbol,
+        sec_type=order.sec_type,
+        exchange=order.exchange,
+        currency=order.currency,
+        side=order.side,
+        quantity=order.quantity,
+        order_type=order.order_type,
+        tif=order.tif,
+        status=order.status,
+        source=order.source,
+        con_id=order.con_id,
+        local_symbol=order.local_symbol,
+        trading_class=order.trading_class,
+        contract_month=order.contract_month,
+        contract_expiry=order.contract_expiry,
+        ib_order_id=order.ib_order_id,
+        ib_perm_id=order.ib_perm_id,
+        filled_quantity=order.filled_quantity,
+        avg_fill_price=order.avg_fill_price,
+        last_error=order.last_error,
+        request_text=order.request_text,
+        submitted_at=order.submitted_at,
+        completed_at=order.completed_at,
+        created_at=order.created_at,
+        updated_at=order.updated_at,
+    )
+
+
+def to_order_event_response(event: OrderEvent) -> OrderEventResponse:
+    return OrderEventResponse(
+        id=event.id,
+        order_id=event.order_id,
+        event_type=event.event_type,
+        message=event.message,
+        status=event.status,
+        filled_quantity=event.filled_quantity,
+        avg_fill_price=event.avg_fill_price,
+        ib_order_id=event.ib_order_id,
+        created_at=event.created_at,
+    )
+
+
+@router.get("/orders", response_model=list[OrderResponse])
+def list_orders(db: Session = Depends(get_db)) -> list[OrderResponse]:
+    stmt = (
+        select(Order, Account)
+        .outerjoin(Account, Order.account_id == Account.id)
+        .order_by(Order.created_at.desc())
+    )
+    rows = db.execute(stmt).all()
+    return [to_order_response(order, account) for order, account in rows]
+
+
+@router.get("/orders/{order_id}", response_model=OrderResponse)
+def get_order(order_id: int, db: Session = Depends(get_db)) -> OrderResponse:
+    stmt = select(Order, Account).outerjoin(Account, Order.account_id == Account.id).where(
+        Order.id == order_id
+    )
+    row = db.execute(stmt).one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Order not found")
+    order, account = row
+    return to_order_response(order, account)
+
+
+@router.post("/orders", response_model=OrderResponse, status_code=201)
+def create_order(body: OrderCreateRequest, db: Session = Depends(get_db)) -> OrderResponse:
+    account = db.get(Account, body.account_id)
+    if account is None:
+        raise HTTPException(status_code=400, detail="Invalid account_id")
+
+    created_at = now_utc()
+    order = Order(
+        account_id=body.account_id,
+        symbol=body.symbol.upper(),
+        sec_type=body.sec_type.upper(),
+        exchange=body.exchange.upper(),
+        currency=body.currency.upper(),
+        side=body.side.upper(),
+        quantity=body.quantity,
+        order_type=body.order_type.upper(),
+        tif=body.tif.upper(),
+        status="queued",
+        source=body.source,
+        request_text=body.request_text,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    db.add(order)
+    db.flush()
+
+    append_order_event(
+        db,
+        order,
+        event_type="order_created",
+        message="Order queued for worker execution.",
+    )
+    db.commit()
+    db.refresh(order)
+    return to_order_response(order, account)
+
+
+@router.get("/orders/{order_id}/events", response_model=list[OrderEventResponse])
+def list_order_events(order_id: int, db: Session = Depends(get_db)) -> list[OrderEventResponse]:
+    order = db.get(Order, order_id)
+    if order is None:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    stmt = select(OrderEvent).where(OrderEvent.order_id == order_id).order_by(OrderEvent.created_at)
+    events = list(db.execute(stmt).scalars().all())
+    return [to_order_event_response(event) for event in events]

--- a/src/api/routers/orders.py
+++ b/src/api/routers/orders.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from src.api.deps import get_db
@@ -12,6 +12,7 @@ from src.models import Account, Order, OrderEvent
 from src.services.order_queue import append_order_event, now_utc
 
 router = APIRouter()
+TERMINAL_ORDER_STATUSES = {"filled", "cancelled", "rejected", "failed"}
 
 
 class OrderCreateRequest(BaseModel):
@@ -192,3 +193,66 @@ def list_order_events(order_id: int, db: Session = Depends(get_db)) -> list[Orde
     stmt = select(OrderEvent).where(OrderEvent.order_id == order_id).order_by(OrderEvent.created_at)
     events = list(db.execute(stmt).scalars().all())
     return [to_order_event_response(event) for event in events]
+
+
+@router.post("/orders/{order_id}/cancel", response_model=OrderResponse)
+def cancel_order(order_id: int, db: Session = Depends(get_db)) -> OrderResponse:
+    stmt = select(Order, Account).outerjoin(Account, Order.account_id == Account.id).where(
+        Order.id == order_id
+    )
+    row = db.execute(stmt).one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Order not found")
+
+    order, account = row
+    if order.status in TERMINAL_ORDER_STATUSES:
+        return to_order_response(order, account)
+
+    if order.status != "queued":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Only queued orders can be cancelled from the UI right now. "
+                f"Current status is '{order.status}'."
+            ),
+        )
+
+    now = now_utc()
+    cancel_stmt = (
+        update(Order)
+        .where(
+            Order.id == order_id,
+            Order.status == "queued",
+        )
+        .values(
+            status="cancelled",
+            completed_at=now,
+            updated_at=now,
+        )
+        .returning(Order.id)
+    )
+    cancelled_order_id = db.execute(cancel_stmt).scalar_one_or_none()
+    if cancelled_order_id is None:
+        current = db.get(Order, order_id)
+        if current is None:
+            raise HTTPException(status_code=404, detail="Order not found")
+        if current.status in TERMINAL_ORDER_STATUSES:
+            return to_order_response(current, account)
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Order state changed before cancellation could be applied. "
+                f"Current status is '{current.status}'."
+            ),
+        )
+
+    db.refresh(order)
+    append_order_event(
+        db,
+        order,
+        event_type="order_cancelled",
+        message="Cancelled from UI before worker submission.",
+    )
+    db.commit()
+    db.refresh(order)
+    return to_order_response(order, account)

--- a/src/api/routers/tradebot.py
+++ b/src/api/routers/tradebot.py
@@ -1,0 +1,324 @@
+"""Tradebot chat router for position queries and queued order creation."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import PlainTextResponse
+from ib_async import IB
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_db
+from src.models import Account, Job, Order, OrderEvent, Position
+from src.services.cl_contracts import select_front_month_contract, to_qualified_contract
+from src.services.jobs import JOB_TYPE_POSITIONS_SYNC, enqueue_job
+from src.services.order_queue import append_order_event, now_utc
+from src.utils.env_vars import get_int_env
+from src.utils.ibkr_account import mask_ibkr_account
+
+router = APIRouter()
+
+
+class ChatPart(BaseModel):
+    type: str
+    text: str | None = None
+
+
+class ChatMessage(BaseModel):
+    role: str
+    parts: list[ChatPart]
+
+
+class TradebotChatRequest(BaseModel):
+    messages: list[ChatMessage]
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    side: str
+    quantity: int
+    symbol: str
+    account_ref: str | None
+
+
+ORDER_INTENT_RE = re.compile(
+    r"\b(?P<side>buy|sell)\b"
+    r"(?:\s+(?P<qty>\d+))?"
+    r"(?:\s+(?:more|additional))?"
+    r"\s+(?P<symbol>[a-z]{1,10})\b",
+    re.IGNORECASE,
+)
+ACCOUNT_REF_RE = re.compile(r"\baccount\s+(?P<account>[a-zA-Z0-9_-]+)\b")
+ORDER_ID_RE = re.compile(r"\border\s+#?(?P<order_id>\d+)\b", re.IGNORECASE)
+
+
+def extract_latest_user_text(messages: list[ChatMessage]) -> str:
+    for message in reversed(messages):
+        if message.role != "user":
+            continue
+        parts = [
+            part.text.strip()
+            for part in message.parts
+            if part.type == "text" and part.text and part.text.strip()
+        ]
+        if parts:
+            return " ".join(parts)
+    raise HTTPException(status_code=400, detail="No user message found")
+
+
+def parse_order_intent(message: str) -> OrderIntent | None:
+    match = ORDER_INTENT_RE.search(message.lower())
+    if match is None:
+        return None
+    side = match.group("side").upper()
+    symbol = match.group("symbol").upper()
+    quantity = int(match.group("qty") or 1)
+    account_match = ACCOUNT_REF_RE.search(message)
+    account_ref = account_match.group("account") if account_match else None
+    return OrderIntent(side=side, quantity=quantity, symbol=symbol, account_ref=account_ref)
+
+
+def resolve_account(session: Session, account_ref: str | None) -> Account:
+    if account_ref is None:
+        account = session.execute(select(Account).order_by(Account.id)).scalars().first()
+        if account is None:
+            raise HTTPException(
+                status_code=400,
+                detail="No account found. Ingest positions first so accounts are available.",
+            )
+        return account
+
+    if account_ref.isdigit():
+        account = session.get(Account, int(account_ref))
+        if account is not None:
+            return account
+
+    stmt = select(Account).where(
+        (func.lower(Account.account) == account_ref.lower())
+        | (func.lower(func.coalesce(Account.alias, "")) == account_ref.lower())
+    )
+    account = session.execute(stmt).scalars().first()
+    if account is None:
+        raise HTTPException(status_code=400, detail=f"Unknown account '{account_ref}'")
+    return account
+
+
+def summarize_positions(session: Session) -> str:
+    stmt = (
+        select(Position, Account)
+        .outerjoin(Account, Position.account_id == Account.id)
+        .order_by(func.abs(Position.position).desc())
+    )
+    rows = session.execute(stmt).all()
+    if not rows:
+        return "No positions found in the database."
+
+    lines = [f"Loaded {len(rows)} position(s). Largest positions:"]
+    for idx, (position, account) in enumerate(rows[:10], start=1):
+        account_name = account.alias if account and account.alias else f"account_id={position.account_id}"
+        symbol = position.symbol or "UNKNOWN"
+        sec_type = position.sec_type or "?"
+        lines.append(
+            f"{idx}. {account_name}: {symbol} {sec_type} qty={position.position:.2f} avg_cost={position.avg_cost:.2f}"
+        )
+    return "\n".join(lines)
+
+
+def is_position_sync_request(lowered_text: str) -> bool:
+    has_positions_word = "position" in lowered_text or "portfolio" in lowered_text
+    has_sync_verb = any(
+        token in lowered_text
+        for token in (
+            "fetch",
+            "refresh",
+            "sync",
+            "download",
+            "update",
+            "pull",
+        )
+    )
+    return has_positions_word and has_sync_verb
+
+
+def queue_position_sync_job(session: Session, prompt: str) -> str:
+    job = enqueue_job(
+        session=session,
+        job_type=JOB_TYPE_POSITIONS_SYNC,
+        payload={},
+        source="tradebot",
+        request_text=prompt,
+    )
+    session.commit()
+    return f"Queued job {job.id} (positions.sync). Worker will fetch current positions from TWS."
+
+
+def summarize_jobs(session: Session) -> str:
+    jobs = (
+        session.execute(select(Job).order_by(Job.created_at.desc()).limit(8))
+        .scalars()
+        .all()
+    )
+    if not jobs:
+        return "No jobs found yet."
+
+    lines = ["Latest jobs:"]
+    for job in jobs:
+        lines.append(
+            f"- Job {job.id}: {job.job_type} status={job.status} attempts={job.attempts}/{job.max_attempts}"
+        )
+    return "\n".join(lines)
+
+
+def qualify_cl_contract(host: str, port: int, client_id: int) -> tuple[str, str | None, str | None, int]:
+    ib = IB()
+    try:
+        ib.connect(host, port, clientId=client_id)
+        qualified = to_qualified_contract(select_front_month_contract(ib))
+        return (
+            qualified.contract_month or "unknown",
+            qualified.local_symbol,
+            qualified.contract_expiry,
+            qualified.con_id,
+        )
+    finally:
+        if ib.isConnected():
+            ib.disconnect()
+
+
+def format_order_progress(session: Session, order_id: int | None = None) -> str:
+    if order_id is not None:
+        order = session.get(Order, order_id)
+        if order is None:
+            return f"No order found for id={order_id}."
+        order_ids = [order.id]
+    else:
+        stmt = select(Order.id).order_by(Order.created_at.desc()).limit(5)
+        order_ids = list(session.execute(stmt).scalars().all())
+        if not order_ids:
+            return "No orders found yet."
+
+    lines: list[str] = []
+    for oid in order_ids:
+        order = session.get(Order, oid)
+        if order is None:
+            continue
+        lines.append(
+            f"Order {order.id}: {order.side} {order.quantity} {order.symbol} "
+            f"status={order.status} filled={order.filled_quantity:.2f} avg_fill={order.avg_fill_price}"
+        )
+        events = (
+            session.execute(
+                select(OrderEvent)
+                .where(OrderEvent.order_id == order.id)
+                .order_by(OrderEvent.created_at.desc())
+                .limit(3)
+            )
+            .scalars()
+            .all()
+        )
+        for event in reversed(events):
+            lines.append(f"- {event.created_at.isoformat()} [{event.event_type}] {event.message}")
+    return "\n".join(lines)
+
+
+def create_queued_cl_order(session: Session, intent: OrderIntent, prompt: str) -> str:
+    if intent.symbol != "CL":
+        return "Tradebot currently supports only CL futures orders. Example: buy 1 CL account 1"
+
+    account = resolve_account(session, intent.account_ref)
+
+    host = "127.0.0.1"
+    try:
+        port = get_int_env("BROKER_TWS_PORT")
+        client_id = get_int_env("TRADEBOT_QUALIFY_CLIENT_ID", 29)
+    except ValueError as exc:
+        return f"Configuration error: {exc}"
+    if port is None:
+        return "Configuration error: BROKER_TWS_PORT is not set."
+
+    try:
+        contract_month, local_symbol, contract_expiry, con_id = qualify_cl_contract(
+            host=host, port=port, client_id=client_id
+        )
+    except Exception as exc:
+        return (
+            "Could not qualify the CL contract from TWS. "
+            f"Ensure TWS/Gateway is running on {host}:{port}. Error: {exc}"
+        )
+
+    created_at = now_utc()
+    order = Order(
+        account_id=account.id,
+        symbol="CL",
+        sec_type="FUT",
+        exchange="NYMEX",
+        currency="USD",
+        side=intent.side,
+        quantity=intent.quantity,
+        order_type="MKT",
+        tif="DAY",
+        status="queued",
+        source="tradebot",
+        con_id=con_id,
+        local_symbol=local_symbol,
+        trading_class="CL",
+        contract_month=contract_month,
+        contract_expiry=contract_expiry,
+        request_text=prompt,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+    session.add(order)
+    session.flush()
+
+    append_order_event(
+        session,
+        order,
+        event_type="order_created",
+        message=(
+            f"Queued by tradebot for {intent.side} {intent.quantity} CL "
+            f"({contract_month}, conId={con_id}, account={mask_ibkr_account(account.account)})."
+        ),
+    )
+    session.commit()
+
+    account_label = account.alias or mask_ibkr_account(account.account)
+    return (
+        f"Queued order {order.id}: {intent.side} {intent.quantity} CL ({contract_month}). "
+        f"Account={account_label}. Worker will submit to TWS and update progress/fills."
+    )
+
+
+@router.post("/tradebot/chat", response_class=PlainTextResponse)
+def tradebot_chat(body: TradebotChatRequest, db: Session = Depends(get_db)) -> str:
+    user_text = extract_latest_user_text(body.messages)
+    lowered = user_text.lower()
+
+    if is_position_sync_request(lowered):
+        return queue_position_sync_job(db, user_text)
+
+    order_intent = parse_order_intent(user_text)
+    if order_intent is not None:
+        return create_queued_cl_order(db, order_intent, user_text)
+
+    if "position" in lowered or "portfolio" in lowered:
+        return summarize_positions(db)
+
+    if "status" in lowered or "progress" in lowered or "fill" in lowered:
+        if "job" in lowered:
+            return summarize_jobs(db)
+        order_match = ORDER_ID_RE.search(lowered)
+        order_id = int(order_match.group("order_id")) if order_match else None
+        return format_order_progress(db, order_id)
+
+    return (
+        "I can help with:\n"
+        "1) position queries (e.g. 'show positions')\n"
+        "2) queue position sync jobs (e.g. 'refresh positions')\n"
+        "3) queue CL orders (e.g. 'buy 1 more CL contracts account 1')\n"
+        "4) progress checks (e.g. 'job status' or 'status for order 12')"
+    )

--- a/src/api/routers/workers.py
+++ b/src/api/routers/workers.py
@@ -1,0 +1,69 @@
+"""Workers API router."""
+
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.api.deps import get_db
+from src.models import WorkerHeartbeat
+from src.services.worker_heartbeat import WORKER_TYPE_JOBS, WORKER_TYPE_ORDERS
+
+router = APIRouter()
+
+GREEN_SECONDS = 12.0
+YELLOW_SECONDS = 30.0
+
+
+class WorkerStatusResponse(BaseModel):
+    worker_type: str
+    light: str
+    status: str
+    heartbeat_at: datetime | None
+    seconds_since_heartbeat: float | None
+    details: str | None
+
+
+def classify_light(status: str, seconds_since_heartbeat: float | None) -> str:
+    if status != "running":
+        return "red"
+    if seconds_since_heartbeat is None:
+        return "red"
+    if seconds_since_heartbeat <= GREEN_SECONDS:
+        return "green"
+    if seconds_since_heartbeat <= YELLOW_SECONDS:
+        return "yellow"
+    return "red"
+
+
+def to_response(now: datetime, row: WorkerHeartbeat | None, worker_type: str) -> WorkerStatusResponse:
+    if row is None:
+        return WorkerStatusResponse(
+            worker_type=worker_type,
+            light="red",
+            status="unknown",
+            heartbeat_at=None,
+            seconds_since_heartbeat=None,
+            details="No heartbeat received yet.",
+        )
+
+    seconds_since = max(0.0, (now - row.heartbeat_at).total_seconds())
+    return WorkerStatusResponse(
+        worker_type=worker_type,
+        light=classify_light(row.status, seconds_since),
+        status=row.status,
+        heartbeat_at=row.heartbeat_at,
+        seconds_since_heartbeat=seconds_since,
+        details=row.details,
+    )
+
+
+@router.get("/workers/status", response_model=list[WorkerStatusResponse])
+def list_worker_statuses(db: Session = Depends(get_db)) -> list[WorkerStatusResponse]:
+    rows = db.execute(select(WorkerHeartbeat)).scalars().all()
+    by_type = {row.worker_type: row for row in rows}
+    now = datetime.now(timezone.utc)
+    worker_types = [WORKER_TYPE_ORDERS, WORKER_TYPE_JOBS]
+    return [to_response(now, by_type.get(worker_type), worker_type) for worker_type in worker_types]

--- a/src/models.py
+++ b/src/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, Float, Integer, String, UniqueConstraint
+from sqlalchemy import JSON, DateTime, Float, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -41,6 +41,119 @@ class Position(Base):
     position: Mapped[float] = mapped_column(Float, nullable=False)
     avg_cost: Mapped[float] = mapped_column(Float, nullable=False)
     fetched_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    account_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    symbol: Mapped[str] = mapped_column(String, nullable=False)
+    sec_type: Mapped[str] = mapped_column(String, nullable=False, default="FUT")
+    exchange: Mapped[str] = mapped_column(String, nullable=False, default="NYMEX")
+    currency: Mapped[str] = mapped_column(String, nullable=False, default="USD")
+    side: Mapped[str] = mapped_column(String, nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False)
+    order_type: Mapped[str] = mapped_column(String, nullable=False, default="MKT")
+    tif: Mapped[str] = mapped_column(String, nullable=False, default="DAY")
+    status: Mapped[str] = mapped_column(String, nullable=False, default="queued")
+    source: Mapped[str] = mapped_column(String, nullable=False, default="tradebot")
+    con_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    local_symbol: Mapped[str | None] = mapped_column(String, nullable=True)
+    trading_class: Mapped[str | None] = mapped_column(String, nullable=True)
+    contract_month: Mapped[str | None] = mapped_column(String, nullable=True)
+    contract_expiry: Mapped[str | None] = mapped_column(String, nullable=True)
+    ib_order_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    ib_perm_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    filled_quantity: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    avg_fill_price: Mapped[float | None] = mapped_column(Float, nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    request_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    submitted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class OrderEvent(Base):
+    __tablename__ = "order_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    order_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    event_type: Mapped[str] = mapped_column(String, nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    status: Mapped[str | None] = mapped_column(String, nullable=True)
+    filled_quantity: Mapped[float | None] = mapped_column(Float, nullable=True)
+    avg_fill_price: Mapped[float | None] = mapped_column(Float, nullable=True)
+    ib_order_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class Job(Base):
+    __tablename__ = "jobs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_type: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="queued")
+    payload: Mapped[dict] = mapped_column(JSON, nullable=False, default=dict)
+    result: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    source: Mapped[str] = mapped_column(String, nullable=False, default="tradebot")
+    request_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    max_attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
+    available_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    archived_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class WorkerHeartbeat(Base):
+    __tablename__ = "worker_heartbeats"
+    __table_args__ = (
+        UniqueConstraint("worker_type", name="uq_worker_heartbeats_worker_type"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    worker_type: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False, default="running")
+    details: Mapped[str | None] = mapped_column(Text, nullable=True)
+    heartbeat_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service modules for trading workflows."""

--- a/src/services/cl_contracts.py
+++ b/src/services/cl_contracts.py
@@ -1,0 +1,97 @@
+"""Helpers for qualifying CL futures contracts via IBKR."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+
+from ib_async import Contract, Future, IB
+
+
+@dataclass(frozen=True)
+class QualifiedContract:
+    con_id: int
+    symbol: str
+    sec_type: str
+    exchange: str
+    currency: str
+    local_symbol: str | None
+    trading_class: str | None
+    contract_month: str | None
+    contract_expiry: str | None
+
+
+def parse_contract_expiry(last_trade_or_month: str) -> dt.date | None:
+    value = (last_trade_or_month or "").strip()
+    if len(value) >= 8 and value[:8].isdigit():
+        try:
+            return dt.datetime.strptime(value[:8], "%Y%m%d").date()
+        except ValueError:
+            return None
+    if len(value) >= 6 and value[:6].isdigit():
+        try:
+            year = int(value[:4])
+            month = int(value[4:6])
+            if month == 12:
+                next_month = dt.date(year + 1, 1, 1)
+            else:
+                next_month = dt.date(year, month + 1, 1)
+            return next_month - dt.timedelta(days=1)
+        except ValueError:
+            return None
+    return None
+
+
+def format_contract_month(contract: Contract) -> str | None:
+    raw_value = (contract.lastTradeDateOrContractMonth or "").strip()
+    if len(raw_value) >= 6 and raw_value[:6].isdigit():
+        return f"{raw_value[:4]}-{raw_value[4:6]}"
+
+    expiry = parse_contract_expiry(raw_value)
+    if expiry is not None:
+        return expiry.strftime("%Y-%m")
+    return None
+
+
+def select_front_month_contract(ib: IB) -> Contract:
+    contract_details = ib.reqContractDetails(Future("CL", exchange="NYMEX", currency="USD"))
+    if not contract_details:
+        raise RuntimeError("No CL futures contract details returned from IBKR")
+
+    today = dt.date.today()
+    candidates: list[tuple[dt.date, Contract]] = []
+    for detail in contract_details:
+        contract = detail.contract
+        if contract is None:
+            continue
+        expiry = parse_contract_expiry(contract.lastTradeDateOrContractMonth)
+        if contract.secType != "FUT" or expiry is None or expiry < today:
+            continue
+        candidates.append((expiry, contract))
+
+    if not candidates:
+        raise RuntimeError("No non-expired CL futures contracts found")
+
+    candidates.sort(key=lambda item: item[0])
+    front_month_contract = candidates[0][1]
+    qualified_contracts = ib.qualifyContracts(front_month_contract)
+    if len(qualified_contracts) != 1:
+        raise RuntimeError(
+            f"Expected exactly one qualified front-month contract, got {len(qualified_contracts)}"
+        )
+    return qualified_contracts[0]
+
+
+def to_qualified_contract(contract: Contract) -> QualifiedContract:
+    raw_expiry = (contract.lastTradeDateOrContractMonth or "").strip()
+    return QualifiedContract(
+        con_id=contract.conId,
+        symbol=contract.symbol or "CL",
+        sec_type=contract.secType or "FUT",
+        exchange=contract.exchange or "NYMEX",
+        currency=contract.currency or "USD",
+        local_symbol=contract.localSymbol,
+        trading_class=contract.tradingClass,
+        contract_month=format_contract_month(contract),
+        contract_expiry=raw_expiry or None,
+    )

--- a/src/services/jobs.py
+++ b/src/services/jobs.py
@@ -1,0 +1,95 @@
+"""Generic job queue primitives."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.models import Job
+
+JOB_STATUS_QUEUED = "queued"
+JOB_STATUS_RUNNING = "running"
+JOB_STATUS_COMPLETED = "completed"
+JOB_STATUS_FAILED = "failed"
+
+JOB_TYPE_POSITIONS_SYNC = "positions.sync"
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def enqueue_job(
+    session: Session,
+    job_type: str,
+    payload: dict,
+    source: str,
+    request_text: str | None,
+    max_attempts: int = 3,
+) -> Job:
+    now = now_utc()
+    job = Job(
+        job_type=job_type,
+        status=JOB_STATUS_QUEUED,
+        payload=payload,
+        result=None,
+        source=source,
+        request_text=request_text,
+        attempts=0,
+        max_attempts=max_attempts,
+        available_at=now,
+        created_at=now,
+        updated_at=now,
+        archived_at=None,
+    )
+    session.add(job)
+    session.flush()
+    return job
+
+
+def claim_next_job(session: Session) -> Job | None:
+    now = now_utc()
+    stmt = (
+        select(Job)
+        .where(
+            Job.status == JOB_STATUS_QUEUED,
+            Job.available_at <= now,
+            Job.archived_at.is_(None),
+        )
+        .order_by(Job.created_at.asc())
+        .limit(1)
+    )
+    job = session.execute(stmt).scalars().first()
+    if job is None:
+        return None
+    job.status = JOB_STATUS_RUNNING
+    job.started_at = now
+    job.updated_at = now
+    session.flush()
+    return job
+
+
+def complete_job(session: Session, job: Job, result: dict) -> None:
+    now = now_utc()
+    job.status = JOB_STATUS_COMPLETED
+    job.result = result
+    job.completed_at = now
+    job.updated_at = now
+    session.flush()
+
+
+def fail_or_retry_job(session: Session, job: Job, error_text: str, retry_delay_seconds: int = 5) -> None:
+    now = now_utc()
+    job.attempts += 1
+    job.last_error = error_text
+    job.updated_at = now
+
+    if job.attempts >= job.max_attempts:
+        job.status = JOB_STATUS_FAILED
+        job.completed_at = now
+    else:
+        job.status = JOB_STATUS_QUEUED
+        job.available_at = now + timedelta(seconds=retry_delay_seconds)
+    session.flush()

--- a/src/services/order_queue.py
+++ b/src/services/order_queue.py
@@ -1,0 +1,94 @@
+"""Order queue lifecycle helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.orm import Session
+
+from src.models import Order, OrderEvent
+
+IB_SUBMITTED_STATUSES = {"submitted", "presubmitted", "pendingsubmit"}
+IB_CANCELLED_STATUSES = {"cancelled", "apicancelled", "inactive"}
+IB_REJECTED_STATUSES = {"rejected"}
+TERMINAL_ORDER_STATUSES = {"filled", "cancelled", "rejected", "failed"}
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def normalize_ib_status(ib_status: str | None, filled_qty: float) -> str:
+    value = (ib_status or "").strip().lower()
+    if value == "filled":
+        return "filled"
+    if value in IB_REJECTED_STATUSES:
+        return "rejected"
+    if value in IB_CANCELLED_STATUSES:
+        return "cancelled"
+    if value in IB_SUBMITTED_STATUSES:
+        if filled_qty > 0:
+            return "partially_filled"
+        return "submitted"
+    if value:
+        return "submitted"
+    return "queued"
+
+
+def append_order_event(
+    session: Session,
+    order: Order,
+    event_type: str,
+    message: str,
+) -> None:
+    session.add(
+        OrderEvent(
+            order_id=order.id,
+            event_type=event_type,
+            message=message,
+            status=order.status,
+            filled_quantity=order.filled_quantity,
+            avg_fill_price=order.avg_fill_price,
+            ib_order_id=order.ib_order_id,
+            created_at=now_utc(),
+        )
+    )
+
+
+def apply_order_progress(
+    order: Order,
+    ib_status: str | None,
+    filled_quantity: float | None,
+    avg_fill_price: float | None,
+    ib_order_id: int | None = None,
+    ib_perm_id: int | None = None,
+) -> bool:
+    previous = (
+        order.status,
+        order.filled_quantity,
+        order.avg_fill_price,
+        order.ib_order_id,
+        order.ib_perm_id,
+    )
+
+    normalized_filled = max(0.0, float(filled_quantity or 0.0))
+    order.status = normalize_ib_status(ib_status, normalized_filled)
+    order.filled_quantity = normalized_filled
+    order.avg_fill_price = avg_fill_price
+    if ib_order_id is not None:
+        order.ib_order_id = ib_order_id
+    if ib_perm_id is not None:
+        order.ib_perm_id = ib_perm_id
+    order.updated_at = now_utc()
+
+    if order.status in TERMINAL_ORDER_STATUSES and order.completed_at is None:
+        order.completed_at = now_utc()
+
+    current = (
+        order.status,
+        order.filled_quantity,
+        order.avg_fill_price,
+        order.ib_order_id,
+        order.ib_perm_id,
+    )
+    return previous != current

--- a/src/services/position_sync.py
+++ b/src/services/position_sync.py
@@ -1,0 +1,104 @@
+"""Sync positions from IBKR into Postgres."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from ib_async import IB
+from sqlalchemy import Engine, inspect, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from src.models import Account, Position
+
+
+def check_positions_tables_ready(engine: Engine) -> None:
+    inspector = inspect(engine)
+    tables = inspector.get_table_names()
+    for required in ("positions", "accounts"):
+        if required not in tables:
+            raise RuntimeError(f"'{required}' table does not exist. Run: task migrate")
+
+
+def get_or_create_accounts(session: Session, account_strings: set[str]) -> dict[str, int]:
+    lookup: dict[str, int] = {}
+    for account_string in account_strings:
+        row = session.execute(
+            select(Account).where(Account.account == account_string)
+        ).scalar_one_or_none()
+        if row is None:
+            row = Account(account=account_string)
+            session.add(row)
+            session.flush()
+        lookup[account_string] = row.id
+    return lookup
+
+
+def sync_positions_once(
+    engine: Engine,
+    host: str,
+    port: int,
+    client_id: int,
+) -> int:
+    ib = IB()
+    try:
+        ib.connect(host, port, clientId=client_id)
+        positions = ib.positions()
+        if not positions:
+            return 0
+
+        now = datetime.now(timezone.utc)
+        with Session(engine) as session:
+            unique_accounts = {position.account for position in positions}
+            account_lookup = get_or_create_accounts(session, unique_accounts)
+
+            for position in positions:
+                contract = position.contract
+                account_id = account_lookup[position.account]
+                stmt = (
+                    insert(Position)
+                    .values(
+                        account_id=account_id,
+                        con_id=contract.conId,
+                        symbol=contract.symbol,
+                        sec_type=contract.secType,
+                        exchange=contract.exchange,
+                        primary_exchange=contract.primaryExchange,
+                        currency=contract.currency,
+                        local_symbol=contract.localSymbol,
+                        trading_class=contract.tradingClass,
+                        last_trade_date=contract.lastTradeDateOrContractMonth,
+                        strike=contract.strike,
+                        right=contract.right,
+                        multiplier=contract.multiplier,
+                        position=position.position,
+                        avg_cost=position.avgCost,
+                        fetched_at=now,
+                    )
+                    .on_conflict_do_update(
+                        constraint="uq_account_id_con_id",
+                        set_={
+                            "symbol": contract.symbol,
+                            "sec_type": contract.secType,
+                            "exchange": contract.exchange,
+                            "primary_exchange": contract.primaryExchange,
+                            "currency": contract.currency,
+                            "local_symbol": contract.localSymbol,
+                            "trading_class": contract.tradingClass,
+                            "last_trade_date": contract.lastTradeDateOrContractMonth,
+                            "strike": contract.strike,
+                            "right": contract.right,
+                            "multiplier": contract.multiplier,
+                            "position": position.position,
+                            "avg_cost": position.avgCost,
+                            "fetched_at": now,
+                        },
+                    )
+                )
+                session.execute(stmt)
+
+            session.commit()
+        return len(positions)
+    finally:
+        if ib.isConnected():
+            ib.disconnect()

--- a/src/services/worker_heartbeat.py
+++ b/src/services/worker_heartbeat.py
@@ -1,0 +1,46 @@
+"""Worker heartbeat upsert helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from src.models import WorkerHeartbeat
+
+WORKER_TYPE_ORDERS = "orders"
+WORKER_TYPE_JOBS = "jobs"
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def upsert_worker_heartbeat(
+    engine: Engine,
+    worker_type: str,
+    status: str,
+    details: str | None = None,
+) -> None:
+    heartbeat_at = now_utc()
+    with Session(engine) as session:
+        row = session.execute(
+            select(WorkerHeartbeat).where(WorkerHeartbeat.worker_type == worker_type)
+        ).scalar_one_or_none()
+        if row is None:
+            row = WorkerHeartbeat(
+                worker_type=worker_type,
+                status=status,
+                details=details,
+                heartbeat_at=heartbeat_at,
+                updated_at=heartbeat_at,
+            )
+            session.add(row)
+        else:
+            row.status = status
+            row.details = details
+            row.heartbeat_at = heartbeat_at
+            row.updated_at = heartbeat_at
+        session.commit()

--- a/src/utils/env_vars.py
+++ b/src/utils/env_vars.py
@@ -1,0 +1,60 @@
+"""Environment variable parsing helpers."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import overload
+
+
+@overload
+def get_int_env(name: str, default: int) -> int: ...
+
+
+@overload
+def get_int_env(name: str, default: None = None) -> int | None: ...
+
+
+def get_int_env(name: str, default: int | None = None) -> int | None:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+
+    if raw.startswith("op://"):
+        raw = resolve_1password_reference(name, raw)
+
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got '{raw}'") from exc
+
+
+def resolve_1password_reference(name: str, reference: str) -> str:
+    try:
+        result = subprocess.run(
+            ["op", "read", reference],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ValueError(
+            f"{name} uses 1Password reference '{reference}', but `op` CLI is not installed."
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        details = (exc.stderr or exc.stdout or "").strip()
+        if details:
+            raise ValueError(
+                f"Could not resolve 1Password reference for {name} ('{reference}'): {details}"
+            ) from exc
+        raise ValueError(
+            f"Could not resolve 1Password reference for {name} ('{reference}'). "
+            "Run `op signin` or start with `op run --env-file=.env.dev -- <command>`."
+        ) from exc
+
+    resolved = result.stdout.strip()
+    if not resolved:
+        raise ValueError(
+            f"1Password reference for {name} ('{reference}') resolved to an empty value."
+        )
+    return resolved


### PR DESCRIPTION
Changes:
- add Trader Bot chat window
- add the concept of Jobs and Orders
- added 2 worker types: Jobs and Orders. The order worker is has event callbacks for execution files.

<img width="4088" height="1340" alt="CleanShot 2026-02-18 at 20 58 46@2x" src="https://github.com/user-attachments/assets/752568a9-91e2-4b4a-a5ca-1df73a307152" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Order management system: create, view, and cancel orders through the API and UI.
  * Tradebot chatbot interface for conversational trading operations and position queries.
  * Job and order processing workers for background execution and task management.
  * Worker status monitoring dashboard showing real-time health of background processes.
  * Jobs table with rerun and archive capabilities for job lifecycle management.

* **Documentation**
  * Added comprehensive architecture guides for worker systems and chatbot functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->